### PR TITLE
feat: 社区教程帖发布器改造为论坛式 Markdown 编辑器

### DIFF
--- a/frontend/src/community/CommunityAdvancedComposer.vue
+++ b/frontend/src/community/CommunityAdvancedComposer.vue
@@ -1,35 +1,211 @@
 <script setup lang="ts">
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { storeToRefs } from 'pinia'
-import { ref } from 'vue'
 import type { CommunityPostType } from '@ai-learning-hub/contracts'
-import { useCommunityStore } from '../stores/community'
-import { useAuthStore } from '../stores/auth'
 import { useCommunityDraft } from './composables/useCommunityDraft'
-import CommunityBlocks from './CommunityBlocks.vue'
-import CommunityComposerTools from './CommunityComposerTools.vue'
+import { useResourceCategories } from './composables/useResourceCategories'
 import CommunityDraftConflict from './CommunityDraftConflict.vue'
+import CommunityEditorToolbar from './CommunityEditorToolbar.vue'
+import AppIcon from '../components/base/AppIcon.vue'
 import { postLabels } from './labels'
 import ResourceContributionFields from './ResourceContributionFields.vue'
-const editor = useCommunityDraft(), store = useCommunityStore(), auth = useAuthStore()
-const paste = (event: ClipboardEvent) => { const files = Array.from(event.clipboardData?.files || []); if (files.length) { event.preventDefault(); void editor.uploadFiles(files) } }
-const drop = (event: DragEvent) => { event.preventDefault(); void editor.uploadFiles(Array.from(event.dataTransfer?.files || [])) }
-const keydown = (event: KeyboardEvent) => { if ((event.ctrlKey || event.metaKey) && event.key === 'Enter') { event.preventDefault(); void editor.save() }; if (event.key === 'Escape') { event.stopPropagation(); editor.close() } }
-const { form, body, code, language, quote, preview, saving, error, blocks, advanced, savedAt } = storeToRefs(editor)
-const { save } = editor
-const tools = ref({ binding: false, topics: false })
+import { loadCommunityImage } from './imageQueue'
+
+const editor = useCommunityDraft()
+const { form, body, saving, error, savedAt, images } = storeToRefs(editor)
+const { save, uploadFiles } = editor
+const textarea = ref<HTMLTextAreaElement>(), imageInput = ref<HTMLInputElement>(), mdInput = ref<HTMLInputElement>()
+const fullscreen = ref(false), menuOpen = ref(false), dragging = ref(false)
+let dragDepth = 0
+
+const typeIcons: Record<CommunityPostType, string> = { question: 'question', note: 'note-edit', lab_result: 'lab-share', project: 'project-maker', frontier_discussion: 'sparkles', achievement: 'achievement', general: 'message' }
+const typeColors: Record<CommunityPostType, string> = { question: 'var(--amc-purple)', note: 'var(--amc-orange)', lab_result: 'var(--amc-green)', project: 'var(--amc-yellow)', frontier_discussion: 'var(--amc-blue)', achievement: 'var(--amc-teal)', general: 'var(--brand)' }
+const categoryCovers: Record<string, string> = { 'ai-foundation': 'cover-llm', 'lab-demo': 'cover-hardware', 'model-deployment': 'cover-deployment', 'agent-practice': 'cover-agent', 'tool-tutorial': 'cover-image', 'creator-share': 'cover-security' }
+
+const { categories, loading: categoriesLoading, load: loadCategories } = useResourceCategories()
+const contributionMode = computed(() => !!form.value.contribution)
+type CategoryOption = { id: string; label: string; icon: string; description: string; coverClass: string; color: string }
+const categoryOptions = computed<CategoryOption[]>(() => contributionMode.value
+  ? categories.value.map((item) => ({ id: item.id, label: item.name, icon: item.icon, description: item.description, coverClass: categoryCovers[item.code] || '', color: categoryCovers[item.code] ? '' : 'var(--brand)' }))
+  : (Object.keys(postLabels) as CommunityPostType[]).map((type) => ({ id: type, label: postLabels[type], icon: typeIcons[type], description: '', coverClass: '', color: typeColors[type] })))
+const activeCategory = computed<CategoryOption>(() => {
+  if (contributionMode.value) {
+    const current = categoryOptions.value.find((item) => item.id === form.value.contribution?.categoryId)
+    if (current) return current
+    return { id: '', label: categoriesLoading.value ? '分类读取中…' : '选择分类', icon: 'folder', description: '', coverClass: '', color: 'var(--brand)' }
+  }
+  return categoryOptions.value.find((item) => item.id === form.value.type) || { id: form.value.type, label: postLabels[form.value.type], icon: typeIcons[form.value.type], description: '', coverClass: '', color: typeColors[form.value.type] }
+})
+const pickCategory = (option: CategoryOption) => {
+  menuOpen.value = false
+  if (!contributionMode.value) { form.value.type = option.id as CommunityPostType; return }
+  const contribution = form.value.contribution
+  if (contribution && option.id) form.value.contribution = { ...contribution, categoryId: option.id }
+}
+
+const needsTitle = computed(() => ['question', 'project'].includes(form.value.type) || contributionMode.value)
+const hasBody = computed(() => !!body.value.trim() || images.value.length > 0)
+const publishDisabled = computed(() => saving.value || !hasBody.value || (needsTitle.value && !form.value.title?.trim()))
+
+const toast = (message: string) => window.dispatchEvent(new CustomEvent('api-error', { detail: { message } }))
+const applySelection = async (build: (selected: string) => { text: string; select: [number, number] }) => {
+  const node = textarea.value
+  if (!node) return
+  const start = node.selectionStart ?? 0, end = node.selectionEnd ?? 0
+  const plan = build(body.value.slice(start, end))
+  body.value = body.value.slice(0, start) + plan.text + body.value.slice(end)
+  await nextTick()
+  node.focus({ preventScroll: true })
+  node.setSelectionRange(start + plan.select[0], start + plan.select[1])
+}
+const wrapMarker = (marker: string, placeholder: string) => applySelection((selected) => {
+  const inner = selected || placeholder
+  return { text: `${marker}${inner}${marker}`, select: [marker.length, marker.length + inner.length] }
+})
+const linePrefix = async (prefix: string) => {
+  const node = textarea.value
+  if (!node) return
+  const start = node.selectionStart ?? 0
+  const lineStart = body.value.lastIndexOf('\n', Math.max(0, start - 1)) + 1
+  const marked = body.value.slice(lineStart).startsWith(prefix)
+  body.value = marked ? body.value.slice(0, lineStart) + body.value.slice(lineStart + prefix.length) : body.value.slice(0, lineStart) + prefix + body.value.slice(lineStart)
+  await nextTick()
+  node.focus({ preventScroll: true })
+  const caret = lineStart + (marked ? 0 : prefix.length)
+  node.setSelectionRange(caret, caret)
+}
+const insertCodeBlock = () => applySelection((selected) => {
+  const inner = selected || '在此粘贴代码'
+  return { text: `\n\`\`\`\n${inner}\n\`\`\`\n`, select: [5, 5 + inner.length] }
+})
+const insertLink = () => applySelection((selected) => {
+  const inner = selected || '链接文字'
+  return { text: `[${inner}](https://)`, select: [inner.length + 3, inner.length + 11] }
+})
+
+const isImageFile = (file: File) => /^image\/(png|jpeg|webp)$/.test(file.type) || /\.(png|jpe?g|webp)$/i.test(file.name)
+const isTextFile = (file: File) => /\.(md|markdown|txt)$/i.test(file.name)
+const readAsText = (file: File) => new Promise<string>((resolve, reject) => {
+  const reader = new FileReader()
+  reader.onload = () => resolve(String(reader.result || ''))
+  reader.onerror = () => reject(new Error('读取失败'))
+  reader.readAsText(file, 'UTF-8')
+})
+const importMarkdown = async (file: File) => {
+  if (file.size > 2 * 1024 * 1024) { toast(`「${file.name}」超过 2MB，无法导入`); return }
+  let text: string
+  try { text = (await readAsText(file)).replace(/\r\n/g, '\n').trim() } catch { toast(`「${file.name}」读取失败，请重试`); return }
+  if (!text) { toast(`「${file.name}」内容为空`); return }
+  const fillEmpty = !body.value.trim()
+  const fill = fillEmpty ? text : `${body.value.replace(/\s+$/, '')}\n\n${text}`
+  if (fill.length > 10000) { toast(`「${file.name}」超过 10000 字正文上限，请拆分后导入`); return }
+  body.value = fill
+  if (fillEmpty && !form.value.title?.trim()) form.value.title = file.name.replace(/\.(md|markdown|txt)$/i, '')
+}
+const routeFiles = (files: File[]) => {
+  const images: File[] = [], docs: File[] = []
+  for (const file of files) {
+    if (isImageFile(file)) images.push(file)
+    else if (isTextFile(file)) docs.push(file)
+    else toast(`暂不支持「${file.name}」，仅支持图片或 .md / .txt 文件`)
+  }
+  if (images.length) void uploadFiles(images)
+  for (const doc of docs) void importMarkdown(doc)
+}
+
+type ToolbarAction = 'bold' | 'italic' | 'heading' | 'list' | 'code' | 'link' | 'image' | 'import-md' | 'fullscreen'
+const onAction = (key: ToolbarAction) => {
+  if (key === 'bold') { void wrapMarker('**', '加粗文字'); return }
+  if (key === 'italic') { void wrapMarker('*', '斜体文字'); return }
+  if (key === 'heading') { void linePrefix('## '); return }
+  if (key === 'list') { void linePrefix('- '); return }
+  if (key === 'code') { void insertCodeBlock(); return }
+  if (key === 'link') { void insertLink(); return }
+  if (key === 'image') { void imageInput.value?.click(); return }
+  if (key === 'import-md') { void mdInput.value?.click(); return }
+  fullscreen.value = !fullscreen.value
+}
+const onPickImages = async (event: Event) => { const target = event.target as HTMLInputElement; await uploadFiles(Array.from(target.files || [])); target.value = '' }
+const onPickMarkdown = (event: Event) => { const target = event.target as HTMLInputElement; for (const file of Array.from(target.files || [])) void importMarkdown(file); target.value = '' }
+const paste = (event: ClipboardEvent) => { const files = Array.from(event.clipboardData?.files || []).filter((file) => isImageFile(file)); if (files.length) { event.preventDefault(); void uploadFiles(files) } }
+const drop = (event: DragEvent) => { event.preventDefault(); dragDepth = 0; dragging.value = false; routeFiles(Array.from(event.dataTransfer?.files || [])) }
+const dragEnter = () => { dragDepth++; dragging.value = true }
+const dragLeave = () => { if (--dragDepth <= 0) { dragDepth = 0; dragging.value = false } }
+const keydown = (event: KeyboardEvent) => {
+  if ((event.ctrlKey || event.metaKey) && event.key === 'Enter') { event.preventDefault(); void save() }
+  if (event.key === 'Escape') {
+    event.stopPropagation()
+    if (menuOpen.value) { menuOpen.value = false; return }
+    if (fullscreen.value) { fullscreen.value = false; return }
+    editor.close()
+  }
+}
+
+const thumbs = ref<Record<string, string>>({})
+let thumbEpoch = 0
+watch(() => images.value.map((image) => image.fileId).join(':'), async () => {
+  const epoch = ++thumbEpoch
+  for (const image of images.value) {
+    if (thumbs.value[image.fileId]) continue
+    try { const url = await loadCommunityImage(image.fileId, () => epoch === thumbEpoch); if (url && epoch === thumbEpoch) thumbs.value[image.fileId] = url } catch { /* 缩略图失败不阻断编辑，发布后由画廊兜底。 */ }
+  }
+}, { immediate: true })
+onBeforeUnmount(() => { thumbEpoch++; Object.values(thumbs.value).forEach((url) => URL.revokeObjectURL(url)) })
+
+onMounted(() => {
+  if (!contributionMode.value) return
+  void loadCategories().then(() => {
+    const contribution = form.value.contribution
+    if (contribution && !contribution.categoryId) form.value.contribution = { ...contribution, categoryId: categories.value.find((item) => item.code === 'uncategorized')?.id }
+  }).catch(() => {})
+})
 </script>
 <template>
-  <form class="dialog-form composer-form" @submit.prevent="save()" @keydown="keydown" @paste="paste" @dragover.prevent @drop="drop">
+  <form class="community-editor" :class="{ 'is-fullscreen': fullscreen }" @submit.prevent="save()" @keydown="keydown" @paste="paste" @dragover.prevent @drop="drop">
     <CommunityDraftConflict />
-    <header class="composer-mobile-top"><button type="button" class="text-link" @click="editor.close()">取消</button><select v-model="form.type" aria-label="发布内容类型"><option v-for="(label, type) in postLabels" :key="type" :value="type">{{ label }}</option></select><button class="button primary small" type="submit" :disabled="saving">{{ saving ? '保存中…' : '发布' }}</button></header>
-    <div class="composer-row"><label>内容类型<select v-model="form.type"><option v-for="(label, type) in postLabels" :key="type" :value="type as CommunityPostType">{{ label }}</option></select></label><details><summary>可见范围：{{ form.visibility === 'school' ? '仅同校用户' : '登录社区用户' }}</summary><label>可见范围<select v-model="form.visibility"><option value="public">登录社区用户</option><option value="school">仅同校用户</option></select></label></details></div>
-    <ResourceContributionFields v-if="form.contribution" />
-    <label v-if="advanced || ['question', 'project'].includes(form.type)">标题{{ ['question', 'project'].includes(form.type) ? '（必填）' : '（选填）' }}<input v-model="form.title" maxlength="160" :required="['question', 'project'].includes(form.type)" placeholder="让同学更容易理解你的问题或收获" /></label>
-    <template v-if="!preview"><label>正文<textarea v-model="body" rows="6" maxlength="15000" required placeholder="说明学习背景、尝试过的方法，以及你的发现……" /></label><details v-if="advanced"><summary>添加代码或引用</summary><label>代码语言<input v-model="language" maxlength="30" /></label><label>代码块（仅展示，不执行）<textarea v-model="code" rows="4" maxlength="12000" /></label><label>引用<textarea v-model="quote" rows="2" maxlength="2000" /></label></details><CommunityComposerTools panel="images" /></template>
-    <CommunityBlocks v-else :blocks="blocks" />
-    <details @toggle="tools.binding = ($event.target as HTMLDetailsElement).open"><summary>添加学习关联（{{ advanced ? 8 : 1 }} 项）</summary><CommunityComposerTools v-if="tools.binding" panel="binding" /></details>
-    <details @toggle="tools.topics = ($event.target as HTMLDetailsElement).open"><summary>设置话题</summary><CommunityComposerTools v-if="tools.topics" panel="topics" /></details>
-    <p v-if="auth.dataMode === 'mock'" class="community-notice">演示图片仅保存在当前浏览器会话，不代表真实上传。</p><p class="composer-privacy">仅发布你确认分享的内容；请勿包含私密笔记、完整成绩、实训日志或密钥。成就草稿不会自动公开。</p><p v-if="error" role="alert" class="community-error">{{ error }}</p>
-    <p v-if="savedAt" role="status" class="muted">{{ savedAt }}</p><div class="composer-actions"><button v-if="!advanced" class="text-link" type="button" @click="store.composerMode = 'advanced'; store.composerInline = false">高级编辑</button><RouterLink to="/community/drafts">草稿箱</RouterLink><button v-if="advanced" class="button secondary" type="button" @click="preview = !preview">{{ preview ? '继续编辑' : '发布预览' }}</button><button class="button secondary" type="button" :disabled="saving" @click="save(true)">保存草稿</button><button class="button primary" type="submit" :disabled="saving">{{ saving ? '正在保存…' : '确认发布' }}</button></div>
+    <header class="editor-head">
+      <div class="editor-category">
+        <button type="button" class="editor-category-toggle" :aria-expanded="menuOpen" aria-haspopup="listbox" :aria-label="contributionMode ? '选择资源分类' : '选择内容类型'" @click="menuOpen = !menuOpen">
+          <span class="editor-category-chip" :class="activeCategory.coverClass" :style="activeCategory.coverClass ? undefined : { background: activeCategory.color }"><AppIcon :name="activeCategory.icon" :size="20" /></span>
+          <strong>{{ activeCategory.label }}</strong>
+          <AppIcon class="editor-category-caret" name="chevron-down" :size="14" />
+        </button>
+        <div v-if="menuOpen" class="editor-category-menu" role="listbox" :aria-label="contributionMode ? '资源分类' : '内容类型'">
+          <button v-for="option in categoryOptions" :key="option.id" type="button" role="option" :aria-selected="option.id === activeCategory.id" @click="pickCategory(option)">
+            <span class="editor-category-chip is-small" :class="option.coverClass" :style="option.coverClass ? undefined : { background: option.color }"><AppIcon :name="option.icon" :size="16" /></span>
+            <span class="editor-category-text"><strong>{{ option.label }}</strong><small v-if="option.description">{{ option.description }}</small></span>
+          </button>
+        </div>
+      </div>
+      <input v-model="form.title" class="editor-title" maxlength="160" aria-label="标题" placeholder="在此输入您主题的标题…" autofocus />
+    </header>
+    <CommunityEditorToolbar :fullscreen-active="fullscreen" @action="onAction" />
+    <input ref="imageInput" class="editor-file-input" type="file" accept="image/png,image/jpeg,image/webp" multiple @change="onPickImages" />
+    <input ref="mdInput" class="editor-file-input" type="file" accept=".md,.markdown,.txt" multiple @change="onPickMarkdown" />
+    <div class="editor-body" :class="{ 'is-dragging': dragging }" @dragenter="dragEnter" @dragleave="dragLeave">
+      <textarea ref="textarea" v-model="body" maxlength="15000" aria-label="正文" placeholder="在此输入您的帖子内容，支持拖放图片和 .md 文件" />
+      <div v-if="images.length" class="editor-images">
+        <figure v-for="(image, index) in images" :key="image.fileId">
+          <img v-if="thumbs[image.fileId]" :src="thumbs[image.fileId]" :alt="image.alt || '待发布的图片'" />
+          <span v-else class="editor-image-wait">读取中…</span>
+          <figcaption><input v-model="image.alt" :aria-label="`第 ${index + 1} 张图片说明`" maxlength="200" placeholder="图片说明（可选）" /><button type="button" class="text-link" @click="images.splice(index, 1)">移除</button></figcaption>
+        </figure>
+      </div>
+      <p v-if="saving" class="editor-upload-state" role="status">正在处理图片或保存草稿…</p>
+    </div>
+    <div v-if="form.contribution && form.contribution.kind !== 'article'" class="editor-panel"><ResourceContributionFields /></div>
+    <p v-if="error" role="alert" class="community-error">{{ error }}</p>
+    <footer class="editor-actions">
+      <div class="editor-actions-side">
+        <RouterLink class="text-link" to="/community/drafts">草稿箱</RouterLink>
+        <small role="status">{{ savedAt || 'Ctrl / ⌘ + Enter 发布' }}</small>
+      </div>
+      <div class="editor-actions-main">
+        <label class="editor-visibility">可见范围<select v-model="form.visibility" aria-label="可见范围"><option value="public">登录社区用户</option><option value="school">仅同校用户</option></select></label>
+        <button class="button secondary" type="button" :disabled="saving" @click="save(true)">存草稿</button>
+        <button class="button primary" type="submit" :disabled="publishDisabled">{{ saving ? '正在保存…' : '发布' }}</button>
+      </div>
+    </footer>
+    <p class="composer-privacy">仅发布你确认分享的内容；请勿包含私密笔记、完整成绩、实训日志或密钥。成就草稿不会自动公开。</p>
   </form>
 </template>

--- a/frontend/src/community/CommunityComposer.vue
+++ b/frontend/src/community/CommunityComposer.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { nextTick, onBeforeUnmount, onMounted, ref } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref } from 'vue'
 import { isNavigationFailure, NavigationFailureType, useRouter } from 'vue-router'
 import AppDialog from '../components/base/AppDialog.vue'
 import AppIcon from '../components/base/AppIcon.vue'
@@ -22,11 +22,16 @@ const removeGuard = router.beforeEach((to) => { if (!store.composerOpen || !edit
 const removeAfter = router.afterEach((to, _from, failure) => { if (store.composerOpen && to.path === '/community/drafts' && (!failure || isNavigationFailure(failure, NavigationFailureType.duplicated))) editor.close(); void nextTick(bindScrollRoot) })
 const finish = async (save: boolean) => { if (save) await editor.saveAndClose(); else editor.discard(); if (!editor.closePrompt) { const next = continuation; continuation = null; next?.() } }
 const cancel = () => { editor.closePrompt = false; continuation = null }
+const composerTitle = computed(() => {
+  if (store.composerMode !== 'advanced') return '分享学习收获'
+  if (store.draft?.contribution?.kind === 'article') return store.editingId ? '编辑教程帖' : '发布教程帖'
+  return store.editingId ? '编辑帖子' : '高级编辑'
+})
 onMounted(() => { window.addEventListener('beforeunload', leave); bindScrollRoot() })
 onBeforeUnmount(() => { removeGuard(); removeAfter(); window.removeEventListener('beforeunload', leave); scrollRoot.value?.removeEventListener('scroll', updateBackToTop) })
 </script>
 <template>
 <div v-if="showBackToTop" class="community-publish-feedback" role="status" aria-live="polite"><button type="button" :aria-label="`${store.publishNotice?.text || '已发布'}，返回社区顶部`" @click="backToTop"><AppIcon name="arrow-right" :size="16" /><span class="community-publish-avatars" aria-hidden="true"><CommunityAvatar v-for="user in (store.context?.suggestedUsers || []).slice(0, 3)" :key="user.id" :src="user.avatar" :username="user.username" :name="user.displayName" size="xs" /></span><strong>已发布</strong></button></div>
-<AppDialog :model-value="store.composerOpen && !store.composerInline" :title="store.composerMode === 'advanced' ? '高级编辑' : '分享学习收获'" class="community-composer" @update:model-value="editor.close()"><template v-if="store.composerOpen && !store.composerInline"><CommunityAdvancedComposer v-if="store.composerMode === 'advanced'" /><CommunityQuickComposer v-else dialog /></template></AppDialog>
+<AppDialog :model-value="store.composerOpen && !store.composerInline" :title="composerTitle" :class="store.composerMode === 'advanced' ? 'community-composer community-editor-dialog' : 'community-composer'" @update:model-value="editor.close()"><template v-if="store.composerOpen && !store.composerInline"><CommunityAdvancedComposer v-if="store.composerMode === 'advanced'" /><CommunityQuickComposer v-else dialog /></template></AppDialog>
 <AppDialog :model-value="editor.closePrompt" title="保留未完成的内容" @update:model-value="cancel"><p>还有正在编辑的内容，你希望怎样离开？</p><div class="composer-actions"><button class="button primary" :disabled="editor.saving" @click="finish(true)">{{ store.editingId && !editor.draftId ? '保留本地副本' : '保存服务器草稿' }}</button><button class="button secondary" @click="finish(false)">放弃修改</button><button class="button secondary" @click="cancel">继续编辑</button></div></AppDialog>
 </template>

--- a/frontend/src/community/CommunityEditorToolbar.vue
+++ b/frontend/src/community/CommunityEditorToolbar.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+const props = defineProps<{ fullscreenActive?: boolean }>()
+const emit = defineEmits<{ action: [key: 'bold' | 'italic' | 'heading' | 'list' | 'code' | 'link' | 'image' | 'import-md' | 'fullscreen'] }>()
+type EditorAction = 'bold' | 'italic' | 'heading' | 'list' | 'code' | 'link' | 'image' | 'import-md' | 'fullscreen'
+
+const glyphs: Record<string, string> = {
+  bold: '<path d="M7.5 5h5.2a3.5 3.5 0 0 1 0 7H7.5zM7.5 12h6.2a3.5 3.5 0 0 1 0 7H7.5z"/>',
+  italic: '<path d="M11 5h7M6 19h7M14.5 5l-5 14"/>',
+  heading: '<path d="M6 5v14M18 5v14M6 12h12"/>',
+  list: '<path d="M9 6h11M9 12h11M9 18h11"/><circle cx="4.4" cy="6" r="1.3" fill="currentColor" stroke="none"/><circle cx="4.4" cy="12" r="1.3" fill="currentColor" stroke="none"/><circle cx="4.4" cy="18" r="1.3" fill="currentColor" stroke="none"/>',
+  code: '<path d="M9 7.5 4.5 12 9 16.5M15 7.5 19.5 12 15 16.5"/>',
+  link: '<path d="M10.2 13.8a4.6 4.6 0 0 0 6.5 0l2.3-2.3a4.6 4.6 0 0 0-6.5-6.5l-1.1 1.1M13.8 10.2a4.6 4.6 0 0 0-6.5 0l-2.3 2.3a4.6 4.6 0 0 0 6.5 6.5l1.1-1.1"/>',
+  image: '<rect x="3.5" y="5" width="17" height="14" rx="2"/><circle cx="9" cy="10" r="1.6" fill="currentColor" stroke="none"/><path d="M5.5 17.5 10 13l3 3 3.5-3.5 3 3"/>',
+  markdown: '<path d="M6.5 3.5h7l5 5V19a1.5 1.5 0 0 1-1.5 1.5H6.5A1.5 1.5 0 0 1 5 19V5a1.5 1.5 0 0 1 1.5-1.5z"/><path d="M13.5 3.5v5h5"/><path d="M12 11v5.5M12 16.5l-2.3-2.3M12 16.5l2.3-2.3"/>',
+  fullscreen: '<path d="M9 4.5H4.5V9M15 4.5h4.5V9M9 19.5H4.5V15M15 19.5h4.5V15"/>',
+}
+type EditorTool = { key: string; label: string; group: number; action: EditorAction; activeKey?: 'fullscreenActive'; tip?: string }
+const tools: EditorTool[] = [
+  { key: 'bold', label: '加粗', group: 0, action: 'bold', tip: '**加粗**' },
+  { key: 'italic', label: '斜体', group: 0, action: 'italic', tip: '*斜体*' },
+  { key: 'heading', label: '标题', group: 0, action: 'heading', tip: '## 标题' },
+  { key: 'list', label: '无序列表', group: 0, action: 'list', tip: '- 列表项' },
+  { key: 'code', label: '代码块', group: 0, action: 'code', tip: '``` 代码块 ```' },
+  { key: 'link', label: '插入链接', group: 1, action: 'link', tip: '[文字](链接)' },
+  { key: 'image', label: '插入图片', group: 1, action: 'image' },
+  { key: 'markdown', label: '导入 .md', group: 1, action: 'import-md', tip: '导入 Markdown 或 TXT 文件' },
+  { key: 'fullscreen', label: '全屏', group: 1, action: 'fullscreen', activeKey: 'fullscreenActive' },
+]
+</script>
+<template>
+  <div class="editor-toolbar" role="toolbar" aria-label="正文格式">
+    <template v-for="(tool, index) in tools" :key="tool.key">
+      <span v-if="index && tool.group !== tools[index - 1]!.group" class="editor-toolbar-divider" aria-hidden="true" />
+      <button
+        type="button"
+        class="editor-tool"
+        :class="{ 'is-active': tool.activeKey && props[tool.activeKey] }"
+        :title="tool.tip || tool.label"
+        :aria-label="tool.label"
+        :aria-pressed="tool.activeKey ? !!props[tool.activeKey] : undefined"
+        @click="emit('action', tool.action)"
+      ><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" v-html="glyphs[tool.key]" /></button>
+    </template>
+  </div>
+</template>

--- a/frontend/src/community/ResourceContributionFields.vue
+++ b/frontend/src/community/ResourceContributionFields.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { ResourceContributionInput, ResourceHubCategoryDto } from '@ai-learning-hub/contracts'
+import type { ResourceContributionInput } from '@ai-learning-hub/contracts'
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useCommunityDraft } from './composables/useCommunityDraft'
@@ -7,8 +7,6 @@ import { resourceHubApi } from '../services/api/resourceHub'
 
 const editor = useCommunityDraft()
 const { form, saving, error } = storeToRefs(editor)
-const categories = ref<ResourceHubCategoryDto[]>([])
-const tags = ref(form.value.contribution?.tags.join('、') || '')
 const uploadProgress = ref(0)
 const uploadStatus = ref('')
 const cancelUpload = ref<(() => void) | null>(null)
@@ -45,7 +43,6 @@ const monitorVideo = (id: string) => {
   const version = operationVersion
   void readVideoStatus(id, version)
 }
-watch(tags, (value) => patch({ tags: [...new Set(value.split(/[、,，]/).map((item) => item.trim()).filter(Boolean))].slice(0, 8) }))
 watch(() => contribution.value.kind, (kind) => {
   stopVideoStatus()
   if (cancelUpload.value) {
@@ -109,30 +106,10 @@ onBeforeUnmount(() => {
   window.removeEventListener('beforeunload', warnBeforeUnload)
   cancelUpload.value?.()
 })
-onMounted(async () => {
-  if (contribution.value.videoAssetId) monitorVideo(contribution.value.videoAssetId)
-  try {
-    categories.value = await resourceHubApi.categories()
-    if (!contribution.value.categoryId) patch({ categoryId: categories.value.find((item) => item.code === 'uncategorized')?.id })
-  } catch (cause) { error.value = cause instanceof Error ? cause.message : '资源分类读取失败' }
-})
+onMounted(() => { if (contribution.value.videoAssetId) monitorVideo(contribution.value.videoAssetId) })
 </script>
 
 <template>
-  <section class="resource-contribution-fields">
-    <h3>资源共创信息</h3>
-    <div class="composer-row">
-      <label>作品形态<select v-model="contribution.kind"><option value="video">视频演示</option><option value="article">图文分享</option><option value="document">配套资料</option></select></label>
-      <label>资源分类<select v-model="contribution.categoryId"><option v-for="item in categories" :key="item.id" :value="item.id">{{ item.name }}</option></select></label>
-    </div>
-    <label>教学标签（最多 8 个）<input v-model="tags" maxlength="160" placeholder="例如：RAG、模型部署、课堂实训" /></label>
-    <label v-if="contribution.kind !== 'article'">{{ contribution.kind === 'video' ? '视频文件（MP4、MOV、WebM，最大 1GB）' : '资料文件（PDF、DOCX、PPTX、ZIP、TXT，最大 100MB）' }}<input type="file" :accept="contribution.kind === 'video' ? 'video/mp4,video/quicktime,video/webm' : '.pdf,.docx,.pptx,.zip,.txt'" :disabled="saving || !!cancelUpload" @change="choose" /></label>
-    <div v-if="uploadStatus" class="resource-upload-state" role="status"><progress :value="uploadProgress" max="100" /><span>{{ uploadStatus }}</span><button v-if="cancelUpload" type="button" class="text-link" @click="cancelUpload()">取消上传</button></div>
-    <template v-if="contribution.kind === 'article'">
-      <label>参考来源名称（选填）<input v-model="contribution.sourceName" maxlength="120" placeholder="原创内容可留空" /></label>
-      <label>参考来源链接（选填）<input v-model="contribution.sourceUrl" type="url" maxlength="500" placeholder="https://…" /></label>
-    </template>
-    <label class="community-checkbox"><input v-model="contribution.teachingReuseConsent" type="checkbox" />允许平台在保留作者署名和原帖链接的前提下，将本作品引用到站内课程草稿</label>
-    <p class="composer-privacy">请确认你有权分享所上传的内容；此授权仅用于站内署名教学引用，不等同于公共开源许可。</p>
-  </section>
+  <label>{{ contribution.kind === 'video' ? '视频文件（MP4、MOV、WebM，最大 1GB）' : '资料文件（PDF、DOCX、PPTX、ZIP、TXT，最大 100MB）' }}<input type="file" :accept="contribution.kind === 'video' ? 'video/mp4,video/quicktime,video/webm' : '.pdf,.docx,.pptx,.zip,.txt'" :disabled="saving || !!cancelUpload" @change="choose" /></label>
+  <div v-if="uploadStatus" class="resource-upload-state" role="status"><progress :value="uploadProgress" max="100" /><span>{{ uploadStatus }}</span><button v-if="cancelUpload" type="button" class="text-link" @click="cancelUpload()">取消上传</button></div>
 </template>

--- a/frontend/src/community/composables/useResourceCategories.ts
+++ b/frontend/src/community/composables/useResourceCategories.ts
@@ -1,0 +1,15 @@
+import { ref } from 'vue'
+import type { ResourceHubCategoryDto } from '@ai-learning-hub/contracts'
+import { resourceHubApi } from '../../services/api/resourceHub'
+
+const categories = ref<ResourceHubCategoryDto[]>([])
+const loading = ref(false)
+let pending: Promise<void> | null = null
+
+export const useResourceCategories = () => {
+  const load = () => pending ||= (async () => {
+    loading.value = true
+    try { categories.value = await resourceHubApi.categories() } catch (cause) { pending = null; throw cause } finally { loading.value = false }
+  })()
+  return { categories, loading, load }
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -7,6 +7,7 @@
 @import "./styles/community/navigation.css";
 @import "./styles/community/feed.css";
 @import "./styles/community/composer.css";
+@import "./styles/community/editor.css";
 @import "./styles/community/post.css";
 @import "./styles/community/rail.css";
 @import "./styles/community/collection.css";

--- a/frontend/src/styles/community/editor.css
+++ b/frontend/src/styles/community/editor.css
@@ -1,0 +1,65 @@
+.community-editor-dialog .dialog-card { width: min(100%, 900px); border-radius: var(--amc-radius-card); }
+
+.community-editor { display: flex; flex-direction: column; gap: 14px; font-size: 15px; line-height: 1.7; color: var(--amc-text-body); }
+
+.community-editor.is-fullscreen { position: fixed; inset: 0; z-index: 60; gap: 12px; padding: 24px; overflow: auto; background: var(--amc-surface); }
+.community-editor.is-fullscreen .editor-body { flex: 1; }
+
+.editor-head { display: flex; align-items: center; gap: 16px; min-width: 0; }
+.editor-category { position: relative; flex-shrink: 0; }
+.editor-category-toggle { display: flex; align-items: center; gap: 10px; min-height: 44px; padding: 2px; border: 0; background: none; cursor: pointer; text-align: left; }
+.editor-category-chip { display: inline-flex; align-items: center; justify-content: center; width: 40px; height: 40px; flex-shrink: 0; border-radius: var(--amc-radius-control); color: var(--amc-surface); }
+.editor-category-chip.is-small { width: 28px; height: 28px; }
+.editor-category-toggle > strong { font-size: 16px; font-weight: 600; color: var(--amc-text-primary); white-space: nowrap; }
+.editor-category-caret { color: var(--amc-text-placeholder); transition: color var(--amc-duration-control) var(--amc-ease); }
+.editor-category-toggle:hover .editor-category-caret { color: var(--amc-text-primary); }
+.editor-category-menu { position: absolute; top: calc(100% + 8px); left: 0; z-index: 30; display: grid; gap: 2px; width: max-content; min-width: 250px; max-width: min(360px, calc(100vw - 48px)); max-height: 320px; overflow-y: auto; padding: 6px; border: 1px solid var(--amc-border); border-radius: var(--amc-radius-control); background: var(--amc-surface); box-shadow: var(--amc-shadow-float); }
+.editor-category-menu > button { display: flex; align-items: center; gap: 10px; min-height: 40px; padding: 7px 9px; border: 0; border-radius: var(--amc-radius-xs); background: none; cursor: pointer; text-align: left; }
+.editor-category-menu > button:hover, .editor-category-menu > button[aria-selected="true"] { background: var(--amc-bg-soft); }
+.editor-category-text { display: grid; gap: 2px; min-width: 0; }
+.editor-category-text strong { font-size: 14px; font-weight: 600; color: var(--amc-text-primary); }
+.editor-category-text small { font-size: 12px; color: var(--amc-text-muted); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.editor-title { flex: 1; min-width: 0; min-height: 44px; padding: 4px 2px 10px; border: 0; border-bottom: 2px solid transparent; border-radius: 0; background: none; font-size: var(--amc-font-post-title); font-weight: 600; color: var(--amc-text-primary); }
+.editor-title::placeholder { color: var(--amc-text-placeholder); font-weight: 500; }
+.editor-title:focus-visible { outline: none; border-bottom-color: var(--brand); }
+
+.editor-toolbar { display: flex; align-items: center; gap: 14px; min-height: 46px; padding: 6px 14px; overflow-x: auto; border-radius: var(--amc-radius-control); background: var(--amc-bg-soft); scrollbar-width: thin; }
+.editor-toolbar-divider { flex-shrink: 0; width: 1px; height: 18px; margin: 0 6px; background: var(--amc-border); }
+.editor-tool { display: inline-flex; align-items: center; justify-content: center; width: 34px; height: 34px; min-height: 34px; flex-shrink: 0; padding: 0; border: 0; border-radius: var(--amc-radius-xs); background: none; color: var(--amc-text-secondary); cursor: pointer; transition: color var(--amc-duration-control) var(--amc-ease), background var(--amc-duration-control) var(--amc-ease); }
+.editor-tool > svg { width: 20px; height: 20px; pointer-events: none; }
+.editor-tool:hover, .editor-tool.is-active { color: var(--brand); background: var(--amc-orange-soft); }
+
+.editor-file-input { display: none; }
+
+.editor-body { position: relative; display: flex; flex-direction: column; gap: 12px; min-height: 480px; padding: 20px; border: 1px solid var(--amc-border); border-radius: var(--amc-radius-control); background: var(--amc-surface); transition: border-color var(--amc-duration-control) var(--amc-ease), background var(--amc-duration-control) var(--amc-ease); }
+.editor-body.is-dragging { border-color: var(--amc-orange-border); background: var(--amc-orange-soft); }
+.editor-body > textarea { flex: 1; min-height: 420px; padding: 0; border: 0; border-radius: 0; background: none; color: var(--amc-text-body); }
+.editor-body > textarea::placeholder { color: var(--amc-text-placeholder); }
+.editor-body > textarea:focus-visible { outline: none; }
+.editor-images { display: grid; gap: 10px; }
+.editor-images figure { display: grid; grid-template-columns: 64px minmax(0, 1fr); gap: 10px; align-items: center; margin: 0; padding: 8px; border: 1px solid var(--amc-border); border-radius: var(--amc-radius-xs); background: var(--amc-bg-page); }
+.editor-images img { width: 64px; height: 64px; object-fit: cover; border-radius: var(--amc-radius-xs); }
+.editor-image-wait { display: inline-flex; align-items: center; justify-content: center; width: 64px; height: 64px; border-radius: var(--amc-radius-xs); background: var(--amc-bg-soft); color: var(--amc-text-muted); font-size: 12px; }
+.editor-images figcaption { display: flex; align-items: center; gap: 10px; }
+.editor-images figcaption input { flex: 1; min-width: 0; min-height: 36px; }
+.editor-upload-state { margin: 0; color: var(--amc-text-muted); font-size: 12px; }
+
+.editor-panel { display: grid; gap: 10px; padding: 12px; border: 1px solid var(--amc-border); border-radius: var(--amc-radius-xs); background: var(--amc-bg-page); font-size: 13px; }
+.editor-panel > label { display: grid; gap: 6px; color: var(--amc-text-body); font-weight: 600; }
+
+.editor-actions { display: flex; align-items: center; justify-content: space-between; gap: 14px; flex-wrap: wrap; }
+.editor-actions-side { display: flex; align-items: center; gap: 16px; flex-wrap: wrap; }
+.editor-actions-side small { color: var(--amc-text-muted); font-size: 12px; }
+.editor-actions-main { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; margin-left: auto; }
+.community-editor .editor-visibility { display: inline-flex; align-items: center; gap: 8px; font-size: 13px; font-weight: 600; color: var(--amc-text-primary); }
+.editor-visibility select { width: auto; min-height: 36px; padding: 0 8px; font-weight: 500; }
+
+@media (max-width: 767px) {
+  .community-editor.is-fullscreen { padding: 14px; }
+  .editor-head { flex-wrap: wrap; }
+  .editor-title { flex-basis: 100%; }
+  .editor-toolbar { gap: 8px; flex-wrap: nowrap; }
+  .editor-toolbar-divider { margin: 0 4px; }
+  .editor-body { min-height: 360px; padding: 16px; }
+  .editor-body > textarea { min-height: 280px; }
+}

--- a/frontend/src/styles/community/responsive.css
+++ b/frontend/src/styles/community/responsive.css
@@ -76,13 +76,6 @@
   .community-composer { padding: 0; }
   .community-composer .dialog-card { display: block; width: 100%; height: 100dvh; max-height: 100dvh; overflow: auto; border-radius: 0; align-content: start; }
   .community-composer .dialog-title { position: sticky; top: 0; z-index: 3; background: var(--amc-surface); padding-block: 10px; }
-  .community-composer .composer-form { padding-bottom: 24px; }
-  .community-composer .composer-mobile-top { display: flex; align-items: center; justify-content: space-between; gap: 12px; background: var(--amc-surface); padding: 14px 0; border-bottom: 1px solid var(--amc-border); }
-  .composer-mobile-top select { max-width: 150px; }
-  .community-composer .composer-form > .composer-row > label:first-child { display: none; }
-  .community-composer .composer-actions { padding: 12px 0; }
-  .community-composer .composer-actions > button[type="submit"] { display: none; }
-  .community-composer .composer-form textarea { min-height: 30dvh; }
   .community-composer details textarea { min-height: 100px; }
   .community-composer .quick-dialog { margin: 0; padding: 0; }
   .composer-topics { grid-template-columns: repeat(2, minmax(0, 1fr)); }


### PR DESCRIPTION
## 背景

社区"发布教程帖"弹窗此前是表单卡片堆叠式编辑器，与社区整体暖色设计语言割裂，也缺少成熟论坛的发帖体验。本次将其重构为 Discourse 三段式布局 + GitHub Issues 精简工具栏 + 掘金 Markdown 编辑体验的发帖编辑器。

## 改动内容

### 三段式布局（CommunityAdvancedComposer 重写）
- **第一行**：左侧 40×40 分类色块（20px 白色线性图标 + 分类名 + 下拉切换），右侧标题输入框占满余宽——无框无底色、聚焦时 2px `var(--brand)` 下划线
- **第二行**：`var(--amc-bg-soft)` 工具条，9 个线性图标分两组（竖分隔线）：格式组（加粗/斜体/标题/无序列表/代码块）｜插入组（链接/插入图片/导入 .md/全屏）；hover 变 `var(--brand)` 并泛 `var(--amc-orange-soft)` 浅底
- **第三行**：正文大卡片（480px 最小高度、20px 内边距），支持工具栏插入 / 拖放 / Ctrl+V 三种图片入口；拖入时边框变 `var(--amc-orange-border)`、底泛 `var(--amc-orange-soft)`
- **底部**：存草稿（次按钮）+ 发布（主按钮，标题或正文为空时置灰），最底部保留隐私提示行

### 删除自创表单
- 移除"资源共创信息"卡片中的作品形态、教学标签、参考来源、授权勾选（`ResourceContributionFields` 精简为纯视频/资料文件上传，仅视频/配套资料流程渲染，教程帖流程完全不出现）
- 移除"引用 / 学习关联 / 话题"页签与演示提示条；弹窗只保留编辑器主体

### 功能
- 工具栏格式按钮映射 Markdown 语法（`**`、`*`、`##`、`-`、\`\`\`、`[文字](链接)`），行内切换无富文本依赖
- 导入 .md：工具栏按钮（`accept=".md,.markdown,.txt"`）与拖放 .md/.txt 等价；FileReader UTF-8 读取，空帖时文件名（去扩展名）自动填标题、内容填正文，非空时追加末尾；超 2MB / 读取失败 / 超 10000 字上限走 toast（复用 `api-error` 事件）
- 拖放按后缀分流：图片走上传、.md/.txt 走文本导入、其他类型 toast 提示
- 全屏按钮：编辑区 fixed 全屏，Esc / 再按退出（Esc 逐级：分类菜单 → 全屏 → 关闭）

### 配色与样式
- 全部使用现有设计变量（`--brand` / `--amc-*` / `--radius-*`），零新增色值
- 分类方块复用六个学习方向已有渐变类 `.cover-llm / .cover-agent / .cover-image / .cover-deployment / .cover-hardware / .cover-security`，默认分类 `var(--brand)` 橙红实底
- 新增 `styles/community/editor.css` 集中承载编辑器样式，`tokens.css` 无净变化
- 窄屏下工具栏横向滚动、不换行错位

## 不变的部分

- 帖子发布接口、草稿、`expectedRevision` 乐观锁与幂等键提交逻辑完全未动，只改表现层与文件导入入口
- 被移除的表单字段（tags / teachingReuseConsent / bindings / topicIds）仍由 draft store 原样保留并提交，编辑存量帖子不丢数据
- 快捷发布器（CommunityQuickComposer）与管理后台不受影响

## 验证

- `npm run lint` ✅
- `npm run typecheck`（vue-tsc）✅
- `vitest run`：166/167 通过（唯一失败为 `learning.api.test.ts` 5s 超时，与本改动无关，单测通过）
- `VITE_DATA_MODE=api npm run build` ✅
