### PR TITLE
feat: 写图文弹窗重构为轻量富文本编辑器（Markdown 导入导出 / 撤销重做 / 自动保存开关）

### DIFF
--- a/frontend/src/community/CommunityAdvancedComposer.vue
+++ b/frontend/src/community/CommunityAdvancedComposer.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
+import { nextTick, onMounted, ref, watch } from 'vue'
 import { storeToRefs } from 'pinia'
-import { ref } from 'vue'
 import type { CommunityPostType } from '@ai-learning-hub/contracts'
 import { useCommunityStore } from '../stores/community'
 import { useAuthStore } from '../stores/auth'
@@ -9,27 +9,232 @@ import CommunityBlocks from './CommunityBlocks.vue'
 import CommunityComposerTools from './CommunityComposerTools.vue'
 import CommunityDraftConflict from './CommunityDraftConflict.vue'
 import { postLabels } from './labels'
-import ResourceContributionFields from './ResourceContributionFields.vue'
 const editor = useCommunityDraft(), store = useCommunityStore(), auth = useAuthStore()
-const paste = (event: ClipboardEvent) => { const files = Array.from(event.clipboardData?.files || []); if (files.length) { event.preventDefault(); void editor.uploadFiles(files) } }
-const drop = (event: DragEvent) => { event.preventDefault(); void editor.uploadFiles(Array.from(event.dataTransfer?.files || [])) }
-const keydown = (event: KeyboardEvent) => { if ((event.ctrlKey || event.metaKey) && event.key === 'Enter') { event.preventDefault(); void editor.save() }; if (event.key === 'Escape') { event.stopPropagation(); editor.close() } }
-const { form, body, code, language, quote, preview, saving, error, blocks, advanced, savedAt } = storeToRefs(editor)
+const { form, body, code, language, quote, preview, saving, error, blocks, advanced, savedAt, autoSaveEnabled } = storeToRefs(editor)
 const { save } = editor
+const paste = (event: ClipboardEvent) => { const files = Array.from(event.clipboardData?.files || []); if (files.length) { event.preventDefault(); void editor.uploadFiles(files) } }
+const dragOver = ref(false)
+const drop = (event: DragEvent) => {
+  event.preventDefault(); dragOver.value = false
+  const files = Array.from(event.dataTransfer?.files || [])
+  const images = files.filter((file) => file.type.startsWith('image/'))
+  const docs = files.filter((file) => /\.(md|markdown)$/i.test(file.name) || file.type === 'text/markdown')
+  if (files.length - images.length - docs.length) error.value = '支持拖入图片与 Markdown 文件'
+  if (images.length) void editor.uploadFiles(images)
+  void (async () => { for (const doc of docs) await importMarkdown(doc) })()
+}
+const importMarkdown = async (file: File) => {
+  if (saving.value) { error.value = '正在保存或上传，请完成后再导入'; return }
+  const raw = await file.text().catch(() => '')
+  if (!raw.trim()) { error.value = `${file.name} 不是有效的 Markdown 文本`; return }
+  let text = raw.replace(/\r\n/g, '\n')
+  const titleMatch = /^#\s+(.+)$/m.exec(text)
+  if (titleMatch && !form.value.title?.trim()) { form.value.title = titleMatch[1].trim().slice(0, 160); text = text.replace(titleMatch[0], '').trimStart() }
+  const codes: Array<{ lang: string; code: string }> = []
+  text = text.replace(/```([^\n`]*)\n([\s\S]*?)```/g, (_match: string, lang: string, block: string) => { codes.push({ lang: lang.trim() || 'text', code: block.replace(/\n$/, '') }); return '' })
+  if (codes.length && !code.value.trim()) { language.value = codes[0].lang; code.value = codes.map((item) => item.code).join('\n\n').slice(0, 12000); codeOpen.value = true }
+  const quoteLines = text.split('\n').filter((line) => line.startsWith('> ')).map((line) => line.slice(2))
+  if (quoteLines.length && !quote.value.trim()) quote.value = quoteLines.join('\n').slice(0, 2000)
+  text = text.split('\n').filter((line) => !line.startsWith('> ')).join('\n').replace(/\n{3,}/g, '\n\n').trim()
+  if (!text.trim() && !codes.length) { error.value = `${file.name} 没有可导入的内容`; return }
+  const room = Math.max(0, 15000 - body.value.length - (body.value ? 2 : 0))
+  const chunk = text.slice(0, room)
+  body.value = body.value ? `${body.value}\n\n${chunk}` : chunk
+  savedAt.value = text.length > room ? `已导入 ${file.name}（超出长度限制部分截断）` : `已导入 ${file.name}`
+}
+const area = ref<HTMLTextAreaElement>()
+const focusArea = (start: number, end: number) => { void nextTick(() => { const el = area.value; if (!el) return; el.focus(); el.setSelectionRange(start, end) }) }
+const surround = (prefix: string, suffix: string, placeholder: string) => {
+  const el = area.value; if (!el) return
+  const start = el.selectionStart ?? body.value.length, end = el.selectionEnd ?? start
+  const selected = body.value.slice(start, end) || placeholder
+  body.value = `${body.value.slice(0, start)}${prefix}${selected}${suffix}${body.value.slice(end)}`
+  focusArea(start + prefix.length, start + prefix.length + selected.length)
+}
+const insertText = (text: string) => {
+  const el = area.value; if (!el) return
+  const start = el.selectionStart ?? body.value.length
+  body.value = `${body.value.slice(0, start)}${text}${body.value.slice(start)}`
+  focusArea(start + text.length, start + text.length)
+}
+const setHeadingLevel = (level: number) => {
+  const el = area.value; if (!el) return
+  const value = body.value, start = el.selectionStart ?? 0
+  const from = value.lastIndexOf('\n', start - 1) + 1
+  const to = value.indexOf('\n', start) === -1 ? value.length : value.indexOf('\n', start)
+  const line = value.slice(from, to), bare = line.replace(/^#{1,3}\s+/, '')
+  const prefix = level === 0 ? '' : `${'#'.repeat(level)} `
+  body.value = `${value.slice(0, from)}${prefix}${bare}${value.slice(to)}`
+  focusArea(from + prefix.length, from + prefix.length + bare.length)
+}
+const headingValue = ref('0')
+const applyHeading = () => { const level = Number(headingValue.value); headingValue.value = '0'; if (level > 0) setHeadingLevel(level) }
+const toggleList = (ordered: boolean) => {
+  const el = area.value; if (!el) return
+  const value = body.value, start = el.selectionStart ?? 0, end = el.selectionEnd ?? start
+  const from = value.lastIndexOf('\n', start - 1) + 1
+  const to = value.indexOf('\n', end) === -1 ? value.length : value.indexOf('\n', end)
+  const lines = (value.slice(from, to) || '').split('\n')
+  const pattern = ordered ? /^\d+[.、]\s*/ : /^[-*]\s*/, other = ordered ? /^[-*]\s*/ : /^\d+[.、]\s*/
+  const all = lines.length > 0 && lines.every((line) => line.trim() && pattern.test(line))
+  const next = lines.map((line, index) => {
+    if (all) return line.replace(pattern, '')
+    if (!line.trim()) return line
+    const bare = line.replace(other, '')
+    return ordered ? `${index + 1}. ${bare}` : `- ${bare}`
+  }).join('\n')
+  body.value = `${value.slice(0, from)}${next}${value.slice(to)}`
+  focusArea(from, from + next.length)
+}
+const insertLink = () => {
+  const el = area.value; if (!el) return
+  const start = el.selectionStart ?? 0, end = el.selectionEnd ?? start
+  const selected = body.value.slice(start, end) || '链接文字'
+  const url = window.prompt('输入链接地址', 'https://')
+  if (!url) return
+  body.value = `${body.value.slice(0, start)}[${selected}](${url})${body.value.slice(end)}`
+}
+const insertHr = () => insertText('\n---\n')
+const tableOpen = ref(false)
+const insertTable = (rows: number, cols: number) => {
+  const head = Array.from({ length: cols }, (_, i) => `列${i + 1}`).join(' | ')
+  const sep = Array.from({ length: cols }, () => '---').join(' | ')
+  const row = Array.from({ length: cols }, () => '内容').join(' | ')
+  insertText(`\n| ${head} |\n| ${sep} |\n${Array.from({ length: rows }, () => row).join('\n')} |\n`)
+  tableOpen.value = false
+}
+/* 撤销 / 重做：正文快照历史 */
+let histTimer: ReturnType<typeof setTimeout> | undefined
+const history = ref<string[]>([body.value]), historyIndex = ref(0), histSuppress = ref(false)
+watch(body, () => {
+  if (histSuppress.value) return
+  clearTimeout(histTimer)
+  histTimer = setTimeout(() => {
+    const current = body.value
+    if (history.value[historyIndex.value] === current) return
+    history.value = history.value.slice(0, historyIndex.value + 1)
+    history.value.push(current)
+    if (history.value.length > 120) history.value.shift()
+    historyIndex.value = history.value.length - 1
+  }, 350)
+})
+const timeTravel = (step: number) => {
+  const target = historyIndex.value + step
+  if (target < 0 || target >= history.value.length) return
+  histSuppress.value = true
+  historyIndex.value = target
+  body.value = history.value[target]
+  void nextTick(() => { histSuppress.value = false })
+}
+const undo = () => timeTravel(-1)
+const redo = () => timeTravel(1)
+const codeOpen = ref(false), emojiOpen = ref(false), livePreview = ref(true)
+const imageInput = ref<HTMLInputElement>(), cameraInput = ref<HTMLInputElement>(), fileInput = ref<HTMLInputElement>()
+const EMOJIS = ['😀', '😄', '😂', '🤔', '😅', '😍', '😎', '😭', '🤯', '👍', '👏', '🙏', '💪', '🤝', '🔥', '✨', '🎉', '❤️', '✅', '❌', '⚠️', '💡', '📚', '🚀', '🤖', '🧠', '🎯', '📌', '📝', '🎓']
+const onPick = (event: Event) => {
+  const target = event.target as HTMLInputElement
+  const files = Array.from(target.files || [])
+  const images = files.filter((file) => file.type.startsWith('image/'))
+  const docs = files.filter((file) => /\.(md|markdown)$/i.test(file.name) || file.type === 'text/markdown')
+  if (files.length - images.length - docs.length) error.value = '仅支持图片与 Markdown 文件，已忽略其他文件'
+  if (images.length) void editor.uploadFiles(images)
+  target.value = ''
+  void (async () => { for (const doc of docs) await importMarkdown(doc) })()
+}
+const addEmoji = (emoji: string) => { insertText(emoji); emojiOpen.value = false }
+const mdInput = ref<HTMLInputElement>()
+const onPickMd = (event: Event) => {
+  const target = event.target as HTMLInputElement
+  const docs = Array.from(target.files || []).filter((file) => /\.(md|markdown)$/i.test(file.name) || file.type === 'text/markdown')
+  if (!docs.length) error.value = '请选择 .md 或 .markdown 文件'
+  target.value = ''
+  void (async () => { for (const doc of docs) await importMarkdown(doc) })()
+}
+const exportMarkdown = () => {
+  const parts: string[] = []
+  if (form.value.title?.trim()) parts.push(`# ${form.value.title.trim()}`, '')
+  if (body.value.trim()) parts.push(body.value.trimEnd(), '')
+  if (quote.value.trim()) parts.push(quote.value.trim().split('\n').map((line) => `> ${line}`).join('\n'), '')
+  if (code.value.trim()) parts.push('```' + (language.value || 'text') + '\n' + code.value.trimEnd() + '\n```', '')
+  const content = parts.join('\n').trimEnd() + '\n'
+  const blob = new Blob([content], { type: 'text/markdown;charset=utf-8' })
+  const url = URL.createObjectURL(blob)
+  const anchor = document.createElement('a')
+  const stamp = new Date().toISOString().slice(0, 10)
+  anchor.href = url
+  anchor.download = `${(form.value.title?.trim() || '未命名').replace(/[\\/:*?"<>|]/g, '_').slice(0, 60)}-${stamp}.md`
+  document.body.appendChild(anchor)
+  anchor.click()
+  anchor.remove()
+  URL.revokeObjectURL(url)
+  savedAt.value = '已导出 Markdown 文件'
+}
+const keydown = (event: KeyboardEvent) => {
+  if ((event.ctrlKey || event.metaKey) && event.key === 'Enter') { event.preventDefault(); void editor.save() }
+  else if (event.key === 'Escape') { event.stopPropagation(); editor.close() }
+  else if ((event.ctrlKey || event.metaKey) && (event.key === 'b' || event.key === 'i') && event.target === area.value) { event.preventDefault(); if (event.key === 'b') surround('**', '**', '加粗文字'); else surround('*', '*', '斜体文字') }
+}
 const tools = ref({ binding: false, topics: false })
+onMounted(() => { history.value = [body.value]; historyIndex.value = 0 })
 </script>
 <template>
-  <form class="dialog-form composer-form" @submit.prevent="save()" @keydown="keydown" @paste="paste" @dragover.prevent @drop="drop">
+  <form class="dialog-form composer-form lite-composer" @submit.prevent="save()" @keydown="keydown" @paste="paste" @dragover.prevent @drop="drop">
     <CommunityDraftConflict />
     <header class="composer-mobile-top"><button type="button" class="text-link" @click="editor.close()">取消</button><select v-model="form.type" aria-label="发布内容类型"><option v-for="(label, type) in postLabels" :key="type" :value="type">{{ label }}</option></select><button class="button primary small" type="submit" :disabled="saving">{{ saving ? '保存中…' : '发布' }}</button></header>
-    <div class="composer-row"><label>内容类型<select v-model="form.type"><option v-for="(label, type) in postLabels" :key="type" :value="type as CommunityPostType">{{ label }}</option></select></label><details><summary>可见范围：{{ form.visibility === 'school' ? '仅同校用户' : '登录社区用户' }}</summary><label>可见范围<select v-model="form.visibility"><option value="public">登录社区用户</option><option value="school">仅同校用户</option></select></label></details></div>
-    <ResourceContributionFields v-if="form.contribution" />
-    <label v-if="advanced || ['question', 'project'].includes(form.type)">标题{{ ['question', 'project'].includes(form.type) ? '（必填）' : '（选填）' }}<input v-model="form.title" maxlength="160" :required="['question', 'project'].includes(form.type)" placeholder="让同学更容易理解你的问题或收获" /></label>
-    <template v-if="!preview"><label>正文<textarea v-model="body" rows="6" maxlength="15000" required placeholder="说明学习背景、尝试过的方法，以及你的发现……" /></label><details v-if="advanced"><summary>添加代码或引用</summary><label>代码语言<input v-model="language" maxlength="30" /></label><label>代码块（仅展示，不执行）<textarea v-model="code" rows="4" maxlength="12000" /></label><label>引用<textarea v-model="quote" rows="2" maxlength="2000" /></label></details><CommunityComposerTools panel="images" /></template>
-    <CommunityBlocks v-else :blocks="blocks" />
+    <div class="lite-editor" :class="{ dragover: dragOver }">
+      <div class="lite-head">
+        <label class="lite-category"><select v-model="form.type" aria-label="内容分类"><option v-for="(label, type) in postLabels" :key="type" :value="type as CommunityPostType">{{ label }}</option></select></label>
+        <input v-model="form.title" class="lite-title" maxlength="160" placeholder="在此输入您主题的标题..." aria-label="标题" />
+      </div>
+      <div class="lite-toolbar" role="toolbar" aria-label="富文本工具栏">
+        <button type="button" class="lite-glyph" title="加粗 (Ctrl+B)" @mousedown.prevent @click="surround('**', '**', '加粗文字')"><strong>B</strong></button>
+        <button type="button" class="lite-glyph" title="斜体 (Ctrl+I)" @mousedown.prevent @click="surround('*', '*', '斜体文字')"><em>I</em></button>
+        <select v-model="headingValue" class="lite-heading" title="标题级别" @change="applyHeading"><option value="0">正文</option><option value="1">标题 1</option><option value="2">标题 2</option><option value="3">标题 3</option></select>
+        <button type="button" title="有序列表" @mousedown.prevent @click="toggleList(true)"><svg class="app-icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><line x1="10" y1="6" x2="20" y2="6" /><line x1="10" y1="12" x2="20" y2="12" /><line x1="10" y1="18" x2="20" y2="18" /><text x="2.2" y="8.4" font-size="8" fill="currentColor" stroke="none" font-family="Georgia, serif">1</text><text x="2.2" y="14.6" font-size="8" fill="currentColor" stroke="none" font-family="Georgia, serif">2</text><text x="2.2" y="20.8" font-size="8" fill="currentColor" stroke="none" font-family="Georgia, serif">3</text></svg></button>
+        <button type="button" title="无序列表" @mousedown.prevent @click="toggleList(false)"><svg class="app-icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><line x1="10" y1="6" x2="20" y2="6" /><line x1="10" y1="12" x2="20" y2="12" /><line x1="10" y1="18" x2="20" y2="18" /><circle cx="4.8" cy="6" r="1.3" fill="currentColor" stroke="none" /><circle cx="4.8" cy="12" r="1.3" fill="currentColor" stroke="none" /><circle cx="4.8" cy="18" r="1.3" fill="currentColor" stroke="none" /></svg></button>
+        <button type="button" title="撤销" :disabled="historyIndex <= 0" @mousedown.prevent @click="undo"><svg class="app-icon" width="18" height="18" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path fill="currentColor" d="M452.266667 413.866667V305.066667a25.173333 25.173333 0 0 0-40.106667-20.906667L145.066667 469.333333a25.6 25.6 0 0 0 0 42.666667l267.093333 186.453333a25.6 25.6 0 0 0 40.106667-21.333333V610.133333a25.6 25.6 0 0 1 26.88-25.6 341.333333 341.333333 0 0 1 301.653333 263.68 336.64 336.64 0 0 0-304.213333-409.173333 25.173333 25.173333 0 0 1-24.32-25.173333z" /></svg></button>
+        <button type="button" title="重做" :disabled="historyIndex >= history.length - 1" @mousedown.prevent @click="redo"><svg class="app-icon" width="18" height="18" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path fill="currentColor" d="M594.944 321.024V153.6L921.6 450.048l-326.656 296.448v-179.2c-90.624 0-371.2 0-492.544 277.504v-30.72c0-123.392 120.832-519.168 492.544-493.056z m0 0" /></svg></button>
+        <button type="button" :class="{ on: codeOpen }" title="代码块 / 引用" @mousedown.prevent @click="codeOpen = !codeOpen"><svg class="app-icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="16 18 22 12 16 6" /><polyline points="8 6 2 12 8 18" /></svg></button>
+        <button type="button" title="插入链接" @mousedown.prevent @click="insertLink"><svg class="app-icon" width="18" height="18" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path fill="currentColor" d="M490.057143 863.085714c-80.457143 80.457143-241.371429 80.457143-329.142857 0-43.885714-43.885714-65.828571-102.4-65.828572-168.228571 0-58.514286 21.942857-117.028571 65.828572-168.228572l117.028571-117.028571-65.828571-51.2-117.028572 117.028571C36.571429 533.942857 0 621.714286 0 702.171429s36.571429 168.228571 95.085714 226.742857 146.285714 80.457143 226.742857 80.457143 168.228571-36.571429 226.742858-95.085715l117.028571-117.028571-65.828571-58.514286-109.714286 124.342857zM928.914286 95.085714c-117.028571-117.028571-329.142857-117.028571-446.171429 0L365.714286 212.114286l58.514285 58.514285 117.028572-117.028571c80.457143-80.457143 241.371429-80.457143 329.142857 0 43.885714 43.885714 65.828571 102.4 65.828571 168.228571s-21.942857 117.028571-65.828571 168.228572l-117.028571 109.714286 58.514285 58.514285 117.028572-117.028571c58.514286-58.514286 95.085714-146.285714 95.085714-226.742857s-36.571429-160.914286-95.085714-219.428572z" /><path fill="currentColor" d="M352.768 615.862857L626.834286 341.869714l56.905143 56.905143L409.6 672.841143z" /></svg></button>
+        <button type="button" title="插入图片" @mousedown.prevent @click="imageInput?.click()"><svg class="app-icon" width="18" height="18" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path fill="currentColor" d="M777.244444 345.0176c0 26.635378-21.592178 48.226844-48.227556 48.226844l-0.255289 0c-26.635378 0-48.227556-21.592178-48.227556-48.226844l0-0.256711c0-26.635378 21.592178-48.226844 48.227556-48.226844l0.255289 0c26.635378 0 48.227556 21.592178 48.227556 48.226844L777.244444 345.0176z" /><path fill="currentColor" d="M798.577778 193.422222l187.022222 0 0 44.8-187.022222 0 0-44.8Z" /><path fill="currentColor" d="M868.977778 122.311111l44.8 0 0 187.022222-44.8 0 0-187.022222Z" /><path fill="currentColor" d="M913.066667 856.940089 913.066667 438.755556l-41.955556 0 0 361.441422L599.657244 433.065956l-165.4784 89.891556-66.388622-89.8496L93.155556 582.2784 93.155556 236.8l581.688889 0 0-42.666667L51.2 194.133333l0 410.934044L51.2 835.555556l0 22.044444 574.712178 0L913.066667 857.6l0.487822 0L913.066667 856.940089zM586.801067 491.032178 824.713956 812.8 648.507022 812.8 461.112178 559.3088 586.801067 491.032178zM96 815.644444 96 631.716267 354.921956 491.079111l54.8544 74.239289 0.042667-0.031289L594.896356 815.644444 96 815.644444z" /></svg></button>
+        <span class="lite-menu-holder">
+          <button type="button" :class="{ on: tableOpen }" title="插入表格" @mousedown.prevent @click="tableOpen = !tableOpen"><svg class="app-icon" width="18" height="18" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path fill="currentColor" d="M512 593.92h57.344V655.36c0 12.288 12.288 24.576 24.576 24.576s24.576-12.288 24.576-24.576v-57.344H675.84c12.288 0 24.576-12.288 24.576-24.576s-12.288-24.576-24.576-24.576h-57.344V491.52c0-12.288-12.288-24.576-24.576-24.576s-24.576 12.288-24.576 24.576v57.344H512c-12.288 0-24.576 12.288-24.576 24.576s12.288 20.48 24.576 20.48z" /><path fill="currentColor" d="M708.608 217.088H315.392c-53.248 0-94.208 40.96-94.208 94.208v372.736C221.184 737.28 266.24 778.24 315.392 778.24h389.12c53.248 0 94.208-40.96 94.208-94.208V311.296c4.096-53.248-40.96-94.208-90.112-94.208zM389.12 733.184H315.392c-24.576 0-49.152-20.48-49.152-49.152v-94.208h122.88v143.36z m0-188.416H270.336v-126.976H389.12v126.976z m364.544 139.264c0 24.576-20.48 49.152-49.152 49.152h-270.336v-315.392h319.488v266.24z m0-311.296H270.336V311.296c0-24.576 20.48-49.152 49.152-49.152h389.12c24.576 0 49.152 20.48 49.152 49.152v61.44z" /></svg></button>
+          <div v-if="tableOpen" class="lite-menu"><button type="button" @mousedown.prevent @click="insertTable(3, 3)">3 列 × 3 行</button><button type="button" @mousedown.prevent @click="insertTable(4, 2)">4 列 × 2 行</button></div>
+        </span>
+        <button type="button" title="分割线" @mousedown.prevent @click="insertHr"><svg class="app-icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><line x1="3" y1="12" x2="21" y2="12" /><circle cx="7" cy="12" r="0.5" fill="currentColor" stroke="none" /><circle cx="12" cy="12" r="0.5" fill="currentColor" stroke="none" /><circle cx="17" cy="12" r="0.5" fill="currentColor" stroke="none" /></svg></button>
+        <button type="button" :class="{ on: emojiOpen }" title="表情" @mousedown.prevent @click="emojiOpen = !emojiOpen"><svg class="app-icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true"><circle cx="11" cy="11" r="8.5" /><path d="M7.8 13.3s1.2 1.7 3.2 1.7 3.2-1.7 3.2-1.7" /><circle cx="8.6" cy="9" r="0.8" fill="currentColor" stroke="none" /><circle cx="13.4" cy="9" r="0.8" fill="currentColor" stroke="none" /><path d="M21.5 18.5l-2.2 3h4.4z" fill="currentColor" stroke="none" /></svg></button>
+        <button type="button" title="拍照上传" @mousedown.prevent @click="cameraInput?.click()"><svg class="app-icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M23 19a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h4l2-3h6l2 3h4a2 2 0 0 1 2 2z" /><circle cx="12" cy="13" r="4" /></svg></button>
+        <button type="button" title="附件（图片 / Markdown）" @mousedown.prevent @click="fileInput?.click()"><svg class="app-icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48" /></svg></button>
+        <button type="button" class="lite-eye" :class="{ on: livePreview }" title="实时预览开关" @mousedown.prevent @click="livePreview = !livePreview"><svg class="app-icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z" /><circle cx="12" cy="12" r="3" /></svg></button>
+      </div>
+      <div v-if="codeOpen" class="lite-code-panel">
+        <label>代码语言<input v-model="language" maxlength="30" placeholder="text / js / python…" /></label>
+        <label>代码块（仅展示，不执行）<textarea v-model="code" rows="4" maxlength="12000" placeholder="粘贴代码…" /></label>
+        <label>引用<textarea v-model="quote" rows="2" maxlength="2000" placeholder="引用一段重要的话…" /></label>
+      </div>
+      <textarea ref="area" v-model="body" class="lite-body" rows="12" maxlength="15000" placeholder="在此处输入您的帖子内容，拖放图像" aria-label="正文" @dragenter.prevent="dragOver = true" @dragleave="dragOver = false"></textarea>
+      <div v-if="emojiOpen" class="lite-emoji"><button v-for="emoji in EMOJIS" :key="emoji" type="button" @mousedown.prevent @click="addEmoji(emoji)">{{ emoji }}</button></div>
+      <div v-if="livePreview" class="lite-live"><small>实时预览</small><CommunityBlocks :blocks="blocks" /></div>
+      <input ref="imageInput" type="file" accept="image/*" multiple hidden @change="onPick" />
+      <input ref="cameraInput" type="file" accept="image/*" capture="environment" hidden @change="onPick" />
+      <input ref="fileInput" type="file" accept="image/*,.md,.markdown" multiple hidden @change="onPick" />
+      <input ref="mdInput" type="file" accept=".md,.markdown" multiple hidden @change="onPickMd" />
+    </div>
+    <CommunityBlocks v-if="preview" :blocks="blocks" />
     <details @toggle="tools.binding = ($event.target as HTMLDetailsElement).open"><summary>添加学习关联（{{ advanced ? 8 : 1 }} 项）</summary><CommunityComposerTools v-if="tools.binding" panel="binding" /></details>
     <details @toggle="tools.topics = ($event.target as HTMLDetailsElement).open"><summary>设置话题</summary><CommunityComposerTools v-if="tools.topics" panel="topics" /></details>
     <p v-if="auth.dataMode === 'mock'" class="community-notice">演示图片仅保存在当前浏览器会话，不代表真实上传。</p><p class="composer-privacy">仅发布你确认分享的内容；请勿包含私密笔记、完整成绩、实训日志或密钥。成就草稿不会自动公开。</p><p v-if="error" role="alert" class="community-error">{{ error }}</p>
-    <p v-if="savedAt" role="status" class="muted">{{ savedAt }}</p><div class="composer-actions"><button v-if="!advanced" class="text-link" type="button" @click="store.composerMode = 'advanced'; store.composerInline = false">高级编辑</button><RouterLink to="/community/drafts">草稿箱</RouterLink><button v-if="advanced" class="button secondary" type="button" @click="preview = !preview">{{ preview ? '继续编辑' : '发布预览' }}</button><button class="button secondary" type="button" :disabled="saving" @click="save(true)">保存草稿</button><button class="button primary" type="submit" :disabled="saving">{{ saving ? '正在保存…' : '确认发布' }}</button></div>
+    <p v-if="savedAt" role="status" class="muted">{{ savedAt }}</p>
+    <div class="composer-actions">
+      <div class="composer-actions-left">
+        <button class="text-link" type="button" title="选择本地 .md 文件导入到编辑器" @click="mdInput?.click()">导入 MD</button>
+        <button class="text-link" type="button" title="把当前内容导出为 .md 文件" @click="exportMarkdown">导出 MD</button>
+        <button v-if="!advanced" class="text-link" type="button" @click="store.composerMode = 'advanced'; store.composerInline = false">高级编辑</button>
+        <button type="button" class="composer-autosave" :class="{ off: !autoSaveEnabled }" :title="autoSaveEnabled ? '点击关闭自动保存' : '点击开启自动保存'" @click="autoSaveEnabled = !autoSaveEnabled">{{ autoSaveEnabled ? '自动保存已开启' : '自动保存已关闭' }}</button>
+      </div>
+      <button class="button secondary" type="button" @click="preview = !preview">{{ preview ? '继续编辑' : '发布预览' }}</button>
+      <button class="button secondary" type="button" :disabled="saving" @click="save(true)">保存草稿</button>
+      <button class="button primary" type="submit" :disabled="saving">{{ saving ? '正在保存…' : '确认发布' }}</button>
+    </div>
   </form>
 </template>

--- a/frontend/src/community/CommunityBlocks.vue
+++ b/frontend/src/community/CommunityBlocks.vue
@@ -7,9 +7,56 @@ const emit = defineEmits<{ overflow: [value: boolean] }>()
 const textRoot = ref<HTMLElement>(), images = computed(() => props.blocks.filter((block) => block.type === 'image'))
 const textBlocks = computed(() => props.blocks.filter((block) => block.type !== 'image'))
 let observer: ResizeObserver | undefined
-const measure = () => { if (props.compact) emit('overflow', [...(textRoot.value?.querySelectorAll<HTMLElement>('p, blockquote, pre') || [])].some((node) => node.scrollHeight > node.clientHeight + 1)) }
+const measure = () => { if (props.compact) emit('overflow', [...(textRoot.value?.querySelectorAll<HTMLElement>('p, blockquote, pre, li') || [])].some((node) => node.scrollHeight > node.clientHeight + 1)) }
 watch([() => props.blocks, () => props.compact], async () => { await nextTick(); measure() })
 onMounted(() => { observer = new ResizeObserver(measure); if (textRoot.value) observer.observe(textRoot.value); measure() })
 onBeforeUnmount(() => observer?.disconnect())
+/* 轻量 Markdown 渲染：先整体转义再受控生成标签，用户内容不会注入 HTML */
+const escapeHtml = (value: string) => value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;')
+const inline = (value: string) => escapeHtml(value)
+  .replace(/`([^`]+)`/g, '<code>$1</code>')
+  .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
+  .replace(/(^|[^*])\*([^*]+)\*/g, '$1<em>$2</em>')
+  .replace(/\[([^\]]+)\]\((https?:\/\/[^)\s]+|\/[^)\s]+)\)/g, '<a href="$2" target="_blank" rel="noopener noreferrer">$1</a>')
+const renderRich = (text: string) => {
+  const out: string[] = []
+  let list: { type: 'ul' | 'ol'; items: string[] } | undefined
+  let table: string[][] | undefined
+  const flushList = () => {
+    if (!list) return
+    const items = list.items.map((item) => `<li>${inline(item)}</li>`).join('')
+    out.push(list.type === 'ul' ? `<ul class="md-list">${items}</ul>` : `<ol class="md-list">${items}</ol>`)
+    list = undefined
+  }
+  const flushTable = () => {
+    if (!table) return
+    if (table.length > 1) {
+      const [head, ...rows] = table
+      const th = head.map((cell) => `<th>${inline(cell)}</th>`).join('')
+      const trs = rows.map((row) => `<tr>${row.map((cell) => `<td>${inline(cell)}</td>`).join('')}</tr>`).join('')
+      out.push(`<table class="md-table"><thead><tr>${th}</tr></thead><tbody>${trs}</tbody></table>`)
+    } else out.push(`<p class="md-p">${inline(table[0].join(' '))}</p>`)
+    table = undefined
+  }
+  for (const raw of text.split('\n')) {
+    const line = raw.trimEnd()
+    const cells = line.startsWith('|') && line.endsWith('|') && line.length > 2 ? line.slice(1, -1).split('|').map((cell) => cell.trim()) : undefined
+    if (cells && !cells.every((cell) => /^:?-{2,}:?$/.test(cell))) { flushList(); table ||= []; table.push(cells); continue }
+    if (cells) continue
+    flushTable()
+    if (/^(?:-{3,}|\*{3,})\s*$/.test(line)) { flushList(); out.push('<hr class="md-hr" />'); continue }
+    const heading = /^(#{1,3})\s+(.+)$/.exec(line)
+    const ulItem = /^[-*]\s+(.+)$/.exec(line)
+    const olItem = /^\d+[.、]\s+(.+)$/.exec(line)
+    if (heading) { flushList(); const level = heading[1].length + 2; out.push(`<h${level} class="md-h">${inline(heading[2])}</h${level}>`); continue }
+    if (ulItem) { if (list && list.type !== 'ul') flushList(); list ||= { type: 'ul', items: [] }; list.items.push(ulItem[1]); continue }
+    if (olItem) { if (list && list.type !== 'ol') flushList(); list ||= { type: 'ol', items: [] }; list.items.push(olItem[1]); continue }
+    flushList()
+    if (!line.trim()) continue
+    out.push(`<p class="md-p">${inline(line)}</p>`)
+  }
+  flushList(); flushTable()
+  return out.join('')
+}
 </script>
-<template><div class="community-content" :class="{ compact }"><div ref="textRoot" class="community-text-blocks"><template v-for="(block, index) in textBlocks" :key="index"><p v-if="block.type === 'paragraph'">{{ block.text }}</p><blockquote v-else-if="block.type === 'quote'">{{ block.text }}</blockquote><div v-else class="community-code"><small>{{ block.language || 'text' }} · 只读代码</small><pre><code>{{ block.code }}</code></pre></div></template></div><CommunityImageGallery v-if="images.length" :images="images" /></div></template>
+<template><div class="community-content" :class="{ compact }"><div ref="textRoot" class="community-text-blocks"><template v-for="(block, index) in textBlocks" :key="index"><div v-if="block.type === 'paragraph'" class="community-md" v-html="renderRich(block.text)" /><blockquote v-else-if="block.type === 'quote'">{{ block.text }}</blockquote><div v-else class="community-code"><small>{{ block.language || 'text' }} · 只读代码</small><pre><code>{{ block.code }}</code></pre></div></template></div><CommunityImageGallery v-if="images.length" :images="images" /></div></template>

--- a/frontend/src/community/CommunityPostCard.vue
+++ b/frontend/src/community/CommunityPostCard.vue
@@ -25,6 +25,42 @@ const unpublish = () => act(async () => { await communityApi.unpublish(props.pos
 const report = () => act(async () => { await communityApi.report(props.post.id, reason.value, description.value); reportOpen.value = false })
 const edit = () => act(async () => { const post = await communityApi.post(props.post.id); store.openComposer({ expectedRevision: post.revision, type: post.type, title: post.title || '', contentBlocks: post.contentBlocks, bindings: post.bindings.filter((b) => b.status !== 'unavailable').map((b) => ({ type: b.type, id: b.id })), topicIds: post.topics.map((t) => t.id), visibility: post.visibility, status: post.status === 'draft' ? 'draft' : 'published', contribution: post.contribution ? { kind: post.contribution.kind, categoryId: post.contribution.categoryId, tags: post.contribution.tags, teachingReuseConsent: post.contribution.teachingReuseConsent, sourceName: post.contribution.sourceName, sourceUrl: post.contribution.sourceUrl, videoAssetId: post.contribution.videoAssetId, attachmentFileId: post.contribution.attachmentFileId, coverFileId: post.contribution.coverFileId } : undefined }, post.id) })
 const openPost = () => { void communityApi.signals({ eventType: 'community_post_click', targetType: 'post', targetId: props.post.id, requestId: props.requestId }).catch(() => undefined) }
+const exportOpen = ref(false)
+const exportPost = (format: 'json' | 'markdown' | 'csv') => {
+  const title = props.post.title || `学习讨论-${props.post.id}`
+  const body = props.post.contentBlocks.map((block) => block.type === 'paragraph' ? block.text : block.type === 'code' ? block.code : block.type === 'quote' ? block.text : block.alt).filter(Boolean).join('\n')
+  const data = {
+    id: props.post.id,
+    title: props.post.title || '',
+    type: props.post.type,
+    typeLabel: postLabels[props.post.type],
+    author: props.post.author.displayName,
+    publishedAt: props.post.publishedAt,
+    topics: props.post.topics.map((topic) => topic.name),
+    content: body,
+  }
+  let content = '', mime = 'text/plain;charset=utf-8', ext = 'txt'
+  if (format === 'json') { content = JSON.stringify(data, null, 2); mime = 'application/json;charset=utf-8'; ext = 'json' }
+  else if (format === 'markdown') {
+    ext = 'md'; content = [
+      `# ${data.title}`,
+      '',
+      `> 类型：${data.typeLabel} · 作者：${data.author} · 时间：${new Date(data.publishedAt).toLocaleString('zh-CN')}`,
+      '',
+      body,
+      '',
+      data.topics.length ? `**话题：** # ${data.topics.join(' # ')}` : '',
+    ].filter((line, index, arr) => line !== '' || arr.slice(0, index).some(Boolean)).join('\n')
+  }
+  else {
+    ext = 'csv'; const esc = (value: string) => `"${String(value).replace(/"/g, '""')}"`
+    content = [['ID', '标题', '类型', '作者', '发布时间', '话题', '内容'].join(','), [data.id, data.title, data.typeLabel, data.author, data.publishedAt, data.topics.join(';'), body].map(esc).join(',')].join('\n')
+  }
+  const url = URL.createObjectURL(new Blob([content], { type: mime }))
+  const link = document.createElement('a')
+  link.href = url; link.download = `${title}.${ext}`; document.body.appendChild(link); link.click(); link.remove(); URL.revokeObjectURL(url)
+  exportOpen.value = false
+}
 const bodyClick = (event: MouseEvent) => {
   if (props.detail || (event.target as HTMLElement).closest('a, button, input, textarea, select, pre, code') || window.getSelection()?.toString()) return
   openPost(); void router.push(`/community/post/${props.post.id}`)
@@ -37,7 +73,7 @@ const bindingClick = (binding: CommunityBindingDto) => {
 }
 </script>
 <template><article class="community-post" :data-post-id="post.id">
-  <header class="community-post-header"><RouterLink class="author-avatar-link" :to="`/community/user/${post.author.username}`"><CommunityAvatar :src="post.author.avatar" :username="post.author.username" :name="post.author.displayName" /></RouterLink><div class="community-author"><RouterLink :to="`/community/user/${post.author.username}`"><strong>{{ post.author.displayName }}</strong><span v-if="post.author.verifiedType !== 'none'" class="community-badge">{{ badgeLabels[post.author.verifiedType] }}</span></RouterLink><small>{{ post.author.school || post.author.major || '学习社区' }} · <RouterLink class="community-post-time" :to="`/community/post/${post.id}`" :title="new Date(post.publishedAt).toLocaleString('zh-CN')" @click="openPost">{{ relativeTime(post.publishedAt) }}</RouterLink><span v-if="post.editedAt"> · 已编辑</span></small></div><span class="community-type" :class="post.type">{{ postLabels[post.type] }}</span><CommunityPostMenu><button v-if="post.author.id !== auth.user?.id" type="button" role="menuitem" :disabled="store.operations[`follow:user:${post.author.id}`]" @click="act(() => store.follow(post.author.id, false, !followingAuthor, undefined, post), false)">{{ followingAuthor ? '取消关注' : '关注作者' }}</button><template v-if="post.author.id === auth.user?.id"><button v-if="showPin && post.status === 'published' && post.visibility === 'public'" type="button" role="menuitem" @click="$emit('pin', pinned ? null : post.id)">{{ pinned ? '取消置顶' : '置顶到个人主页' }}</button><button type="button" role="menuitem" @click="edit">编辑动态</button><button v-if="post.contribution && post.status === 'published'" type="button" role="menuitem" @click="unpublishOpen = true">下架为草稿</button><button type="button" role="menuitem" @click="deleteOpen = true">删除动态</button></template><button type="button" role="menuitem" @click="hide('hide')">隐藏此内容</button><button type="button" role="menuitem" @click="hide('not-interested')">减少此类内容</button><template v-if="post.author.id !== auth.user?.id"><button type="button" role="menuitem" @click="hide('mute')">静音作者</button><button type="button" role="menuitem" @click="hide('block')">屏蔽作者</button></template><button type="button" role="menuitem" @click="reportOpen = true">举报内容</button></CommunityPostMenu></header>
+  <header class="community-post-header"><RouterLink class="author-avatar-link" :to="`/community/user/${post.author.username}`"><CommunityAvatar :src="post.author.avatar" :username="post.author.username" :name="post.author.displayName" /></RouterLink><div class="community-author"><RouterLink :to="`/community/user/${post.author.username}`"><strong>{{ post.author.displayName }}</strong><span v-if="post.author.verifiedType !== 'none'" class="community-badge">{{ badgeLabels[post.author.verifiedType] }}</span></RouterLink><small>{{ post.author.school || post.author.major || '学习社区' }} · <RouterLink class="community-post-time" :to="`/community/post/${post.id}`" :title="new Date(post.publishedAt).toLocaleString('zh-CN')" @click="openPost">{{ relativeTime(post.publishedAt) }}</RouterLink><span v-if="post.editedAt"> · 已编辑</span></small></div><span class="community-type" :class="post.type">{{ postLabels[post.type] }}</span><button class="community-type community-export-btn" type="button" @click="exportOpen = true">瀵煎嚭</button><CommunityPostMenu><button v-if="post.author.id !== auth.user?.id" type="button" role="menuitem" :disabled="store.operations[`follow:user:${post.author.id}`]" @click="act(() => store.follow(post.author.id, false, !followingAuthor, undefined, post), false)">{{ followingAuthor ? '取消关注' : '关注作者' }}</button><template v-if="post.author.id === auth.user?.id"><button v-if="showPin && post.status === 'published' && post.visibility === 'public'" type="button" role="menuitem" @click="$emit('pin', pinned ? null : post.id)">{{ pinned ? '取消置顶' : '置顶到个人主页' }}</button><button type="button" role="menuitem" @click="edit">编辑动态</button><button v-if="post.contribution && post.status === 'published'" type="button" role="menuitem" @click="unpublishOpen = true">下架为草稿</button><button type="button" role="menuitem" @click="deleteOpen = true">删除动态</button></template><button type="button" role="menuitem" @click="hide('hide')">隐藏此内容</button><button type="button" role="menuitem" @click="hide('not-interested')">减少此类内容</button><template v-if="post.author.id !== auth.user?.id"><button type="button" role="menuitem" @click="hide('mute')">静音作者</button><button type="button" role="menuitem" @click="hide('block')">屏蔽作者</button></template><button type="button" role="menuitem" @click="reportOpen = true">举报内容</button></CommunityPostMenu></header>
   <div v-if="post.question" class="question-state"><span :class="{ solved: post.question.status === 'solved' }"><AppIcon v-if="post.question.status === 'solved'" name="check" :size="14" />{{ post.question.status === 'solved' ? '已解决' : '等待回答' }}</span><small v-if="post.question.teacherAnswered">认证教师参与回答</small></div>
   <h2 v-if="post.title" class="community-post-title"><RouterLink :to="`/community/post/${post.id}`" @click="openPost">{{ post.title }}</RouterLink></h2>
   <div :class="{ 'community-post-body': !detail }" @click="bodyClick"><CommunityBlocks :blocks="post.contentBlocks" :compact="!detail && !expanded" @overflow="overflowed = $event" /></div>
@@ -54,4 +90,5 @@ const bindingClick = (binding: CommunityBindingDto) => {
   <AppDialog v-model="reportOpen" title="举报内容"><form class="dialog-form" @submit.prevent="report"><label>举报原因<select v-model="reason"><option>内容不准确</option><option>不当内容或骚扰</option><option>泄露个人信息</option><option>垃圾广告</option><option>版权问题</option></select></label><label>补充说明<textarea v-model="description" maxlength="1000" rows="3" /></label><p>举报信息仅供有权限的审核人员处理，不向作者公开。</p><button class="button primary" :disabled="pending">提交举报</button></form></AppDialog>
   <AppDialog v-model="unpublishOpen" title="下架自己的资源作品"><p>作品将从资源中心、社区、作者页和合集公开入口撤下，并保留为私人草稿，之后仍可编辑并重新发布。</p><button class="button primary" :disabled="pending" @click="unpublish">确认下架</button></AppDialog>
   <AppDialog v-model="deleteOpen" title="删除自己的动态"><p>动态将不再对社区显示，讨论记录保留用于审计。</p><button class="button primary" :disabled="pending" @click="remove">确认删除</button></AppDialog>
+  <AppDialog v-model="exportOpen" title="导出动态"><p>选择导出格式：</p><div class="community-export-options"><button class="button secondary" type="button" @click="exportPost('json')">JSON</button><button class="button secondary" type="button" @click="exportPost('markdown')">Markdown</button><button class="button secondary" type="button" @click="exportPost('csv')">CSV</button></div></AppDialog>
 </article></template>

--- a/frontend/src/styles/community/composer.css
+++ b/frontend/src/styles/community/composer.css
@@ -1,4 +1,4 @@
-.community-quick-composer { position: relative; isolation: isolate; margin: 14px 0 20px; min-height: 156px; padding: 22px 24px 18px; border: 1px solid var(--amc-border); border-radius: 18px; background: linear-gradient(110deg, var(--amc-surface) 40%, var(--amc-surface-peach)); box-shadow: var(--amc-shadow-card); transition: background var(--amc-duration-expand) var(--amc-ease); }
+.community-quick-composer { position: relative; isolation: isolate; margin: 14px 0 20px; min-height: 156px; padding: 22px 24px 18px; border: 1px solid #cfcfcf; border-radius: 18px; background: #f5f0e8; box-shadow: var(--amc-shadow-card); transition: background var(--amc-duration-expand) var(--amc-ease); }
 .composer-decoration { position: absolute; inset: 0 0 0 auto; z-index: -1; width: 54%; height: 100%; max-width: 420px; object-fit: contain; object-position: right center; pointer-events: none; opacity: .78; border-radius: inherit; }
 .quick-prompt { display: flex; align-items: center; gap: 14px; width: 100%; min-height: 50px; padding: 0; border: 0; background: none; text-align: left; color: var(--amc-text-secondary); cursor: text; }
 .quick-prompt > span:last-child { max-width: 67%; font-size: 17px; font-weight: 600; line-height: 1.55; }
@@ -41,7 +41,13 @@
 .composer-topics label { display: flex; align-items: center; gap: 7px; font-size: 12px; }
 .composer-topics input, .community-checkbox input { width: auto; min-height: 0; }
 .composer-privacy { font-size: 12px; background: var(--amc-bg-page); padding: 12px; border-radius: var(--amc-radius-xs); margin: 0; }
-.composer-actions { display: flex; gap: 10px; justify-content: flex-end; flex-wrap: wrap; }
+.composer-actions { display: flex; gap: 10px; justify-content: flex-end; flex-wrap: wrap; align-items: center; }
+.composer-actions-left { display: flex; align-items: center; gap: 10px; margin-right: auto; flex-wrap: wrap; }
+.composer-actions > a { display: inline-flex; align-items: center; margin-left: 8px; }
+.composer-autosave { display: inline-flex; align-items: center; gap: 6px; margin-left: 8px; padding: 0 4px; border: 0; background: transparent; font-size: 12px; font-weight: 600; color: var(--amc-text-secondary); cursor: pointer; }
+.composer-autosave::before { content: ''; width: 6px; height: 6px; border-radius: 50%; background: var(--amc-success); }
+.composer-autosave:hover { color: var(--amc-text-primary); }
+.composer-autosave.off::before { background: #c8cfd8; }
 .community-chip { border: 0; background: var(--amc-purple-soft); border-radius: var(--amc-radius-xs); padding: 4px 8px; min-height: 30px; overflow-wrap: anywhere; font-size: 12px; }
 .community-composer .dialog-card { width: min(100%, 720px); }
 .community-publish-feedback { position: fixed; z-index: 40; right: 28px; bottom: 28px; }
@@ -57,3 +63,40 @@
 .composer-tool-panel > label { display: grid; gap: 8px; }
 .composer-tool-panel p { margin: 0; }
 .composer-mobile-top { display: none; }
+.lite-editor { display: grid; gap: 10px; padding: 12px; border: 1px solid var(--amc-border); border-radius: var(--amc-radius-control); background: var(--amc-surface); transition: border-color var(--amc-duration-control) var(--amc-ease); }
+.lite-editor.dragover { border-color: var(--amc-orange-border); box-shadow: 0 0 0 3px var(--amc-orange-soft); }
+.lite-head { display: flex; align-items: center; gap: 10px; min-width: 0; }
+.lite-category { flex-shrink: 0; margin: 0; }
+.lite-category select { min-height: 36px; height: 36px; padding: 0 26px 0 13px; border: 1px solid var(--amc-orange-border); border-radius: var(--amc-radius-pill); background: var(--amc-orange-soft); color: var(--amc-orange); font-size: 13px; font-weight: 700; cursor: pointer; appearance: none; }
+.lite-category select:focus-visible { outline: 1px solid var(--amc-orange-border); outline-offset: 1px; }
+.lite-title { flex: 1; min-width: 0; height: 40px; min-height: 40px; padding: 0 12px; border: 1px solid transparent; border-radius: 10px; background: transparent; font-size: 1.02rem; font-weight: 650; box-shadow: none; }
+.lite-title::placeholder { color: var(--amc-text-placeholder); }
+.lite-title:focus { outline: 0; border-color: var(--amc-orange-border); background: var(--amc-bg-soft); }
+.lite-toolbar { display: flex; flex-wrap: wrap; align-items: center; gap: 2px; padding: 0 0 10px; border: 0; background: transparent; }
+.lite-toolbar button { display: inline-grid; place-items: center; min-width: 32px; height: 32px; padding: 0; border: 0; border-radius: 8px; background: transparent; color: #8f99a8; cursor: pointer; transition: color var(--amc-duration-control) var(--amc-ease); }
+.lite-toolbar button:hover { color: var(--amc-text-primary); }
+.lite-toolbar button.on { color: var(--amc-orange); }
+.lite-toolbar .lite-glyph { font-family: Georgia, 'Times New Roman', serif; font-size: 17px; font-weight: 400; }
+.lite-toolbar .lite-glyph strong { font-weight: 700; }
+.lite-toolbar button:disabled { color: #c8cfd8; cursor: default; }
+.lite-toolbar select.lite-heading { height: 32px; min-height: 32px; padding: 0 4px 0 6px; border: 0; border-radius: 8px; background: transparent; color: #8f99a8; font-size: 13px; font-weight: 600; cursor: pointer; }
+.lite-toolbar select.lite-heading:hover { color: var(--amc-text-primary); }
+.lite-menu-holder { position: relative; display: inline-grid; }
+.lite-menu { position: absolute; top: 36px; left: 0; z-index: 20; display: grid; gap: 2px; padding: 6px; border: 1px solid var(--amc-border); border-radius: 10px; background: var(--amc-surface); box-shadow: var(--amc-shadow-float); white-space: nowrap; }
+.lite-menu button { justify-items: start; min-width: 0; height: 30px; padding: 0 10px; font-size: 13px; font-weight: 500; color: var(--amc-text-body); }
+.lite-menu button:hover { color: var(--amc-orange); }
+.lite-toolbar .lite-eye { margin-left: auto; }
+.lite-live { display: grid; gap: 6px; max-height: 260px; overflow-y: auto; padding: 10px 12px; border: 1px dashed var(--amc-border); border-radius: 10px; background: var(--amc-surface); }
+.lite-live > small { color: var(--amc-text-secondary); font-size: 11px; }
+.lite-live .community-content { font-size: .92rem; }
+.lite-toolbar .lite-ol { font-size: 13px; letter-spacing: -.02em; }
+.lite-body { min-height: 264px; padding: 12px 14px; border: 1px solid var(--amc-border); border-radius: 10px; background: var(--amc-surface); resize: vertical; line-height: 1.75; font-size: .95rem; box-shadow: none; }
+.lite-body::placeholder { color: var(--amc-text-placeholder); }
+.lite-body:focus { outline: 0; border-color: var(--amc-orange-border); }
+.lite-code-panel { display: grid; gap: 8px; padding: 10px; border: 1px dashed var(--amc-border); border-radius: 10px; background: var(--amc-bg-soft); }
+.lite-code-panel label { display: grid; gap: 4px; font-size: 12px; color: var(--amc-text-secondary); }
+.lite-code-panel input, .lite-code-panel textarea { padding: 7px 10px; border: 1px solid var(--amc-border); border-radius: 8px; box-shadow: none; font-size: 13px; }
+.lite-code-panel textarea { line-height: 1.6; }
+.lite-emoji { display: flex; flex-wrap: wrap; gap: 3px; padding: 8px; border: 1px solid var(--amc-border); border-radius: 10px; background: var(--amc-surface); }
+.lite-emoji button { min-width: 34px; height: 32px; border: 0; border-radius: 8px; background: transparent; font-size: 17px; cursor: pointer; }
+.lite-emoji button:hover { background: var(--amc-bg-soft); }

--- a/frontend/src/styles/community/post.css
+++ b/frontend/src/styles/community/post.css
@@ -10,6 +10,9 @@
 .community-type.lab_result { color: var(--amc-success); background: var(--amc-green-soft); }
 .community-type.project { color: var(--amc-warning); background: var(--amc-yellow-soft); }
 .community-type.question { color: var(--amc-purple); background: var(--amc-purple-soft); }
+.community-export-btn { cursor: pointer; border: 0; min-height: 0; background: var(--amc-orange-soft); color: var(--amc-orange); font-size: 12px; line-height: 1.5; border-radius: var(--amc-radius-xs); padding: 3px 7px; white-space: nowrap; font-weight: 600; transition: background var(--amc-duration-control) var(--amc-ease), color var(--amc-duration-control) var(--amc-ease); }
+.community-export-btn:hover { background: var(--amc-orange); color: #ffffff; }
+.community-export-options { display: flex; gap: 10px; flex-wrap: wrap; margin-top: 14px; }
 .community-post-menu { position: relative; align-self: start; }
 .community-menu-trigger { cursor: pointer; padding: 6px; min-height: 36px; color: var(--amc-text-secondary); border: 0; background: transparent; border-radius: var(--amc-radius-xs); }
 .community-menu-panel { position: fixed; inset: auto; margin: 0; width: 180px; max-width: calc(100vw - 16px); max-height: calc(100dvh - 16px); overflow: auto; padding: 5px; background: var(--amc-surface); color: var(--amc-text-primary); border: 1px solid var(--amc-border); border-radius: var(--amc-radius-control); box-shadow: var(--amc-shadow-float); }
@@ -67,3 +70,17 @@
 .question-state > span { background: var(--amc-yellow-soft); color: var(--amc-warning); font-size: 12px; border-radius: var(--amc-radius-xs); padding: 4px 7px; }
 .question-state > span.solved { background: var(--amc-green-soft); color: var(--amc-success); }
 .question-state small { color: var(--amc-text-secondary); font-size: 12px; }
+.community-md { overflow-wrap: anywhere; }
+.community-md .md-p { white-space: pre-wrap; overflow-wrap: anywhere; font-size: var(--amc-font-body-large); line-height: 1.75; margin: 0 0 12px; color: var(--amc-text-body); }
+.community-md .md-h { margin: 16px 0 8px; line-height: 1.4; letter-spacing: -.01em; }
+.community-md h3.md-h { font-size: 1.18em; }
+.community-md h4.md-h { font-size: 1.08em; }
+.community-md h5.md-h { font-size: 1em; }
+.community-md .md-list { margin: 0 0 12px; padding-left: 24px; color: var(--amc-text-body); font-size: var(--amc-font-body-large); line-height: 1.75; }
+.community-md .md-list li { margin: 2px 0; }
+.community-md code { padding: 1px 6px; border-radius: 6px; background: var(--amc-bg-soft); border: 1px solid var(--amc-border-soft); font-size: .92em; }
+.community-md .md-table { width: 100%; margin: 4px 0 12px; border-collapse: collapse; font-size: .92em; overflow-wrap: anywhere; }
+.community-md .md-table th, .community-md .md-table td { border: 1px solid var(--amc-border); padding: 7px 10px; text-align: left; }
+.community-md .md-table th { background: var(--amc-bg-soft); font-weight: 650; }
+.community-md a { color: var(--amc-orange); }
+.community-md .md-hr { border: 0; border-top: 1px solid var(--amc-border); margin: 14px 0; }


### PR DESCRIPTION
## 改动说明

### 写图文弹窗重构（CommunityAdvancedComposer.vue）
- 整体改为三段式轻量编辑器：**内容分类标签 + 标题输入 → 富文本工具栏 → 大正文编辑区**
- 移除「资源共创信息」整组字段（作品形态/资源分类/教学标签/参考来源名称与链接/授权提示/学习图片上传/独立「添加代码或引用」入口）及「可见范围」提示文案
- 工具栏（扁平灰线图标）：加粗 B、斜体 I、标题级别下拉（正文/标题 1-3，应用到当前行）、有序/无序列表（多行自动编号、可取消）、**撤销/重做**（正文快照历史）、代码块（整合原「添加代码或引用」：语言+代码+引用）、插入链接、插入图片、插入表格（3×3 / 4×2 下拉模板）、分割线、表情面板、相机拍照、附件
- 正文支持拖放/粘贴图片上传；支持三种方式导入 .md 文件（拖拽 / 附件按钮 / 「导入 MD」按钮）：一级标题自动填标题栏、代码块进代码面板、引用行进引用面板、其余进正文
- 「导出 MD」按钮：将标题+正文+引用+代码打包下载为标准 Markdown 文件
- 自动保存改为**可点击开关**（自动保存已开启/已关闭），手动「保存草稿」「确认发布」不受影响；输入停 2 秒存本地草稿、10 秒同步服务器草稿的机制保持不变
- 底部动作行分组：左侧（导入 MD / 导出 MD / 高级编辑 / 自动保存开关），右侧（发布预览 / 保存草稿 / 确认发布）
- 新增实时预览窗格，边写边看真实排版效果

### 正文渲染器（CommunityBlocks.vue）
- 段落支持轻量 Markdown 渲染：加粗、斜体、行内代码、链接、标题(#/##/###)、有序/无序列表、表格、分割线
- 安全实现：先整体 HTML 转义、再受控生成标签，用户内容不会注入页面

### 样式（composer.css / post.css）
- 新增轻量编辑器、Markdown 内容（表格/列表/行内代码/分割线）、自动保存开关样式
- 随文件附带少量同文件内的既有微调（帖子卡导出按钮样式、快捷发布器配色）

### 质量验证
- `npm run lint`、`npm run typecheck` 全部通过

> 其他部分（侧栏图标、信息流行内搜索等）未包含在本 PR 中。