### PR TITLE
feat: 新增学时排名页与社区侧栏入口（总榜/本周榜）

### DIFF
--- a/frontend/src/community/labels.ts
+++ b/frontend/src/community/labels.ts
@@ -17,6 +17,7 @@ export const relativeTime = (value: string, now = Date.now()) => {
 }
 export const communityNavigation = [
   { label: '社区首页', path: '/community', icon: 'message', desktop: true, mobile: true, mobileOrder: 1, requiresAuth: true },
+  { label: '学时排名', path: '/study-ranking', icon: 'trophy', desktop: true, mobile: false, mobileOrder: 0, requiresAuth: true },
   { label: '学习主题', path: '/topics', icon: 'layers', desktop: true, mobile: true, mobileOrder: 2, requiresAuth: true },
   { label: '实训项目', path: '/labs', icon: 'terminal', desktop: true, mobile: false, mobileOrder: 0, requiresAuth: true },
   { label: '资源中心', path: '/resources', icon: 'folder', desktop: true, mobile: false, mobileOrder: 0, requiresAuth: true },

--- a/frontend/src/router.ts
+++ b/frontend/src/router.ts
@@ -23,6 +23,7 @@ const router = createRouter({
     { path: '/notifications', component: () => import('./community/NotificationsView.vue'), meta: { title: '消息通知', requiresAuth: true, layout: 'community', communityMode: 'wide' } },
     { path: '/__homepage-preview', name: 'homepage-preview', component: () => import('./views/HomepagePreviewView.vue'), meta: { title: '落地页草稿预览', layout: 'landing', requiresAuth: false } },
     { path: '/topics', name: 'topics', component: () => import('./views/TopicsView.vue'), meta: { title: '学习主题', layout: 'adaptive', requiresAuth: true, communityMode: 'wide' } },
+{ path: '/study-ranking', name: 'study-ranking', component: () => import('./views/StudyRankingView.vue'), meta: { title: '学时排名', layout: 'adaptive', requiresAuth: true, communityMode: 'wide' } },
     { path: '/courses/:courseId', name: 'course', component: () => import('./views/CourseView.vue'), meta: { title: '课程学习', layout: 'adaptive', requiresAuth: true, communityMode: 'wide' } },
     { path: '/labs', name: 'labs', component: () => import('./views/LabsView.vue'), meta: { title: '实训项目', layout: 'adaptive', requiresAuth: true, communityMode: 'wide' } },
     { path: '/labs/:labId', name: 'lab', component: () => import('./views/LabWorkspaceView.vue'), meta: { title: '实训工作台', dark: true, layout: 'immersive', requiresAuth: true } },

--- a/frontend/src/views/StudyRankingView.vue
+++ b/frontend/src/views/StudyRankingView.vue
@@ -1,0 +1,102 @@
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import PageHero from '../components/PageHero.vue'
+import CommunityAvatar from '../components/base/CommunityAvatar.vue'
+import { useAuthStore } from '../stores/auth'
+
+interface RankingRow { name: string; username: string; school: string; major: string; hours: number }
+
+const auth = useAuthStore()
+const tab = ref<'total' | 'week'>('total')
+
+/* 演示榜单：同学名单与学时为固定演示数据；「我」的学时同样为演示值 */
+const classmates: RankingRow[] = [
+  { name: '张一帆', username: 'zhangyifan', school: 'AI 创客学院', major: '人工智能', hours: 328 },
+  { name: '李思远', username: 'lisiyuan', school: '数智工程学院', major: '计算机科学', hours: 289 },
+  { name: '王梓萌', username: 'wangzimeng', school: 'AI 创客学院', major: '软件工程', hours: 263 },
+  { name: '陈子豪', username: 'chenzihao', school: '信息学院', major: '数据科学', hours: 242 },
+  { name: '刘雨欣', username: 'liuyuxin', school: 'AI 创客学院', major: '人工智能', hours: 224 },
+  { name: '赵晨阳', username: 'zhaochenyang', school: '数智工程学院', major: '软件工程', hours: 205 },
+  { name: '孙悦', username: 'sunyue', school: '信息学院', major: '计算机科学', hours: 190 },
+  { name: '周博文', username: 'zhoubowen', school: 'AI 创客学院', major: '数据科学', hours: 175 },
+  { name: '吴佳琪', username: 'wujiaqi', school: '数智工程学院', major: '人工智能', hours: 161 },
+  { name: '郑浩然', username: 'zhenghaoran', school: 'AI 创客学院', major: '计算机科学', hours: 149 },
+  { name: '何静怡', username: 'hejingyi', school: '信息学院', major: '软件工程', hours: 136 },
+  { name: '高天佑', username: 'gaotianyou', school: 'AI 创客学院', major: '人工智能', hours: 124 },
+  { name: '林晓峰', username: 'linxiaofeng', school: '数智工程学院', major: '数据科学', hours: 113 },
+  { name: '罗雪', username: 'luoxue', school: '信息学院', major: '计算机科学', hours: 102 },
+  { name: '梁俊', username: 'liangjun', school: 'AI 创客学院', major: '软件工程', hours: 93 },
+  { name: '宋佳霖', username: 'songjialin', school: '数智工程学院', major: '人工智能', hours: 84 },
+  { name: '唐悦然', username: 'tangyueran', school: '信息学院', major: '计算机科学', hours: 76 },
+  { name: '韩明轩', username: 'hanmingxuan', school: 'AI 创客学院', major: '数据科学', hours: 68 },
+  { name: '冯思涵', username: 'fengsihan', school: '数智工程学院', major: '计算机科学', hours: 61 },
+  { name: '曹宇航', username: 'caoyuhang', school: '信息学院', major: '软件工程', hours: 54 }
+]
+const weeklyHours = [16, 13, 11, 10, 9, 9, 8, 7, 7, 6, 6, 5, 5, 4, 4, 3, 3, 2, 2, 2]
+
+const me = computed<RankingRow>(() => ({
+  name: `${auth.user?.displayName || '我'}（我）`,
+  username: auth.user?.username || 'me',
+  school: auth.user?.school || 'AI 创客学院',
+  major: auth.user?.major || '计算机科学与技术',
+  hours: tab.value === 'total' ? 126 : 12
+}))
+const board = computed<RankingRow[]>(() => {
+  const rows = classmates.map((row, index) => ({ ...row, hours: tab.value === 'total' ? row.hours : weeklyHours[index] ?? 1 }))
+  rows.push({ ...me.value, hours: me.value.hours })
+  return rows.sort((a, b) => b.hours - a.hours)
+})
+const podium = computed(() => board.value.slice(0, 3))
+const rest = computed(() => board.value.slice(3))
+const isMe = (row: RankingRow) => row.username === (auth.user?.username || 'me')
+</script>
+<template>
+  <div class="page-container study-ranking-page">
+    <PageHero eyebrow="学习社区" title="学时排名" description="看看谁在学习上投入最多时间，向身边的榜样看齐。" visual-key="assessmentsHeroAssetId" />
+    <nav class="community-filters" aria-label="榜单切换">
+      <button :class="{ active: tab === 'total' }" type="button" @click="tab = 'total'">总榜</button>
+      <button :class="{ active: tab === 'week' }" type="button" @click="tab = 'week'">本周榜</button>
+    </nav>
+    <section class="ranking-podium">
+      <article v-for="(row, index) in podium" :key="row.username" :class="['rank-top', `rank-${index + 1}`]">
+        <strong class="rank-medal">{{ ['🥇', '🥈', '🥉'][index] }}</strong>
+        <CommunityAvatar :src="undefined" :username="row.username" :name="row.name" />
+        <strong class="rank-name">{{ row.name }}</strong>
+        <small>{{ row.school }} · {{ row.major }}</small>
+        <strong class="rank-hours">{{ row.hours }}<small> 学时</small></strong>
+      </article>
+    </section>
+    <section>
+      <ol class="rank-list">
+        <li v-for="(row, index) in rest" :key="row.username" :class="{ 'rank-me': isMe(row) }">
+          <span class="rank-no">{{ index + 4 }}</span>
+          <CommunityAvatar :src="undefined" :username="row.username" :name="row.name" size="xs" />
+          <span class="rank-name">{{ row.name }}<small>{{ row.school }} · {{ row.major }}</small></span>
+          <span class="rank-hours"><strong>{{ row.hours }}</strong> 学时<em v-if="isMe(row)">我</em></span>
+        </li>
+      </ol>
+    </section>
+    <p class="notice study-demo-note">当前为演示榜单：同学名单与学时为平台演示数据，用于展示排名功能。</p>
+  </div>
+</template>
+<style scoped>
+.ranking-podium { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 14px; margin: 22px 0; }
+.ranking-podium article { display: grid; justify-items: center; gap: 6px; padding: 20px 14px 16px; border: 1px solid var(--border); border-radius: var(--radius-card); background: white; text-align: center; }
+.rank-top.rank-1 { border-color: #f0c14b; box-shadow: 0 6px 18px rgba(240, 193, 75, .18); }
+.rank-top.rank-2 { border-color: #c9cdd4; }
+.rank-top.rank-3 { border-color: #d9a06b; }
+.rank-medal { font-size: 26px; line-height: 1; }
+.rank-top .rank-name { font-size: 15px; }
+.rank-top small { color: var(--muted); font-size: 12px; }
+.rank-hours { font-size: 20px; font-weight: 750; color: var(--brand); }
+.rank-hours small { font-size: 12px; font-weight: 500; color: var(--muted); }
+ol.rank-list { padding-left: 0; margin: 0; list-style: none; }
+.rank-list li { display: flex; align-items: center; gap: 12px; padding: 12px 10px; border-bottom: 1px solid var(--border); border-radius: 10px; }
+.rank-list li.rank-me { background: #fff7f0; border-left: 3px solid var(--brand); }
+.rank-no { width: 30px; color: var(--muted); font-weight: 700; }
+.rank-name { display: grid; gap: 2px; flex: 1; min-width: 0; font-weight: 650; overflow-wrap: anywhere; }
+.rank-name small { color: var(--muted); font-size: 12px; font-weight: 400; }
+.rank-list .rank-hours { font-size: 15px; }
+.rank-list em { font-style: normal; margin-left: 8px; padding: 1px 7px; border-radius: 999px; background: var(--amc-orange-soft); color: var(--amc-orange); font-size: 11px; }
+.study-demo-note { margin: 16px 0 0; }
+</style>


### PR DESCRIPTION
## 改动说明

### 新功能：学时排名

- **社区侧栏新增「学时排名」入口**：位于「社区首页」下方（发现与学习分组，trophy 图标），仅桌面侧栏与更多菜单显示，不进移动端底部导航
- **新增路由** `/study-ranking`（`layout: adaptive`、`communityMode: wide`、需登录）
- **新增页面 `StudyRankingView.vue`**：
  - 页面头图（PageHero）+ 总榜 / 本周榜切换
  - 前三名领奖台（金/银/铜样式）+ 完整榜单列表
  - 当前登录用户行高亮并标注「我」
  - 榜单为演示数据（20 位同学，名单与学时固定稳定），页面底部有「演示榜单」说明
  - 页面样式使用 scoped 局部样式，复用全局既有类（community-filters / rank-list / notice），未新增全局样式文件

### 质量验证
- `npm run lint`、`npm run typecheck` 全部通过

> 仅包含学时排名相关 3 个文件（labels.ts / router.ts / StudyRankingView.vue），不涉及其他改动。