### PR TITLE
feat: 社区内容一键复制与多格式下载（带作者水印）

### DIFF
--- a/frontend/src/community/CommunityBlocks.vue
+++ b/frontend/src/community/CommunityBlocks.vue
@@ -1,15 +1,59 @@
 <script setup lang="ts">
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import type { CommunityContentBlock } from '@ai-learning-hub/contracts'
+import AppIcon from '../components/base/AppIcon.vue'
 import CommunityImageGallery from './CommunityImageGallery.vue'
-const props = defineProps<{ blocks: CommunityContentBlock[]; compact?: boolean }>()
+const props = defineProps<{ blocks: CommunityContentBlock[]; compact?: boolean; author?: string; origin?: string }>()
 const emit = defineEmits<{ overflow: [value: boolean] }>()
 const textRoot = ref<HTMLElement>(), images = computed(() => props.blocks.filter((block) => block.type === 'image'))
 const textBlocks = computed(() => props.blocks.filter((block) => block.type !== 'image'))
+const copiedIndex = ref(-1), failedIndex = ref(-1), menuIndex = ref(-1)
+let copyTimer: ReturnType<typeof setTimeout> | undefined
+const copyLabel = (index: number) => copiedIndex.value === index ? '已复制' : failedIndex.value === index ? '复制失败，请手动选择' : '复制'
+const copyCode = async (index: number, code: string) => {
+  try {
+    await navigator.clipboard.writeText(code)
+    copiedIndex.value = index; failedIndex.value = -1
+  } catch {
+    failedIndex.value = index; copiedIndex.value = -1
+  } finally {
+    clearTimeout(copyTimer)
+    copyTimer = setTimeout(() => { copiedIndex.value = -1; failedIndex.value = -1 }, 1800)
+  }
+}
+const codeExtensions: Record<string, string> = { python: 'py', py: 'py', bash: 'sh', sh: 'sh', shell: 'sh', zsh: 'sh', javascript: 'js', js: 'js', typescript: 'ts', ts: 'ts', java: 'java', c: 'c', cpp: 'cpp', 'c++': 'cpp', csharp: 'cs', 'c#': 'cs', go: 'go', rust: 'rs', ruby: 'rb', php: 'php', swift: 'swift', kotlin: 'kt', sql: 'sql', json: 'json', yaml: 'yml', toml: 'toml', html: 'html', xml: 'xml', css: 'css', markdown: 'md', md: 'md' }
+const commentPrefixes: Record<string, string> = { python: '#', py: '#', bash: '#', sh: '#', shell: '#', zsh: '#', yaml: '#', yml: '#', toml: '#', ruby: '#', r: '#', sql: '--', lua: '--', haskell: '--' }
+const codeExt = (language: string) => codeExtensions[language.trim().toLowerCase()] || 'txt'
+const watermarkLines = (prefix = '') => {
+  const lines = ['来源：AI 数智化学习平台 · 题盒社区', `作者：${props.author || '社区学习者'}`, ...(props.origin ? [`出处：${props.origin}`] : []), `下载时间：${new Date().toLocaleString('zh-CN')}`]
+  return prefix ? lines.map((line) => `${prefix} ${line}`) : lines
+}
+const download = (index: number, code: string, language: string, format: 'txt' | 'md' | 'code') => {
+  const key = language.trim().toLowerCase()
+  const base = `${(props.author || 'community').replace(/[\\/:*?"<>|\s]+/g, '-')}-code-${index + 1}`
+  let content = '', name = base, type = 'text/plain;charset=utf-8'
+  if (format === 'md') {
+    content = [`> ${watermarkLines().join(' · ')}`, '', `\`\`\`${language.trim()}`, code, '```'].join('\n')
+    name = `${base}.md`; type = 'text/markdown;charset=utf-8'
+  } else if (format === 'code') {
+    content = [...watermarkLines(commentPrefixes[key] || '//'), '', code].join('\n')
+    name = `${base}.${codeExt(language)}`
+  } else {
+    content = [...watermarkLines(), '————————————', code].join('\n')
+  }
+  const url = URL.createObjectURL(new Blob([content], { type }))
+  const anchor = document.createElement('a')
+  anchor.href = url; anchor.download = name
+  document.body.appendChild(anchor); anchor.click(); anchor.remove()
+  URL.revokeObjectURL(url)
+  menuIndex.value = -1
+}
+const onDocClick = (event: MouseEvent) => { if (menuIndex.value >= 0 && !(event.target as HTMLElement).closest('.community-code-download')) menuIndex.value = -1 }
+onMounted(() => { if (typeof document !== 'undefined' && typeof document.addEventListener === 'function') document.addEventListener('click', onDocClick) })
 let observer: ResizeObserver | undefined
 const measure = () => { if (props.compact) emit('overflow', [...(textRoot.value?.querySelectorAll<HTMLElement>('p, blockquote, pre') || [])].some((node) => node.scrollHeight > node.clientHeight + 1)) }
 watch([() => props.blocks, () => props.compact], async () => { await nextTick(); measure() })
 onMounted(() => { observer = new ResizeObserver(measure); if (textRoot.value) observer.observe(textRoot.value); measure() })
-onBeforeUnmount(() => observer?.disconnect())
+onBeforeUnmount(() => { if (typeof document !== 'undefined' && typeof document.removeEventListener === 'function') document.removeEventListener('click', onDocClick); clearTimeout(copyTimer); observer?.disconnect() })
 </script>
-<template><div class="community-content" :class="{ compact }"><div ref="textRoot" class="community-text-blocks"><template v-for="(block, index) in textBlocks" :key="index"><p v-if="block.type === 'paragraph'">{{ block.text }}</p><blockquote v-else-if="block.type === 'quote'">{{ block.text }}</blockquote><div v-else class="community-code"><small>{{ block.language || 'text' }} · 只读代码</small><pre><code>{{ block.code }}</code></pre></div></template></div><CommunityImageGallery v-if="images.length" :images="images" /></div></template>
+<template><div class="community-content" :class="{ compact }"><div ref="textRoot" class="community-text-blocks"><template v-for="(block, index) in textBlocks" :key="index"><p v-if="block.type === 'paragraph'">{{ block.text }}</p><blockquote v-else-if="block.type === 'quote'">{{ block.text }}</blockquote><div v-else class="community-code"><div class="community-code-head"><small>{{ block.language || 'text' }} · 只读代码</small><div class="community-code-actions"><button type="button" class="community-code-copy" :class="{ 'is-copied': copiedIndex === index, 'is-failed': failedIndex === index }" aria-label="复制代码全文" @click="copyCode(index, block.code)"><AppIcon name="git" :size="13" /><span>{{ copyLabel(index) }}</span></button><details class="community-code-download" :open="menuIndex === index" @toggle="menuIndex = ($event.target as HTMLDetailsElement).open ? index : -1"><summary aria-label="下载代码文件">下载<AppIcon name="chevron-down" :size="12" /></summary><div class="community-code-menu"><button type="button" @click="download(index, block.code, block.language || '', 'txt')">纯文本 .txt</button><button type="button" @click="download(index, block.code, block.language || '', 'md')">Markdown .md</button><button type="button" @click="download(index, block.code, block.language || '', 'code')">源码文件 .{{ codeExt(block.language || '') }}</button></div></details></div></div><pre><code>{{ block.code }}</code></pre></div></template></div><CommunityImageGallery v-if="images.length" :images="images" /></div></template>

--- a/frontend/src/community/CommunityPostCard.vue
+++ b/frontend/src/community/CommunityPostCard.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import type { CommunityPostSummaryDto, CommunityBindingDto, CommunitySignalInput } from '@ai-learning-hub/contracts'
 import { useAuthStore } from '../stores/auth'
@@ -11,6 +11,7 @@ import CommunityAvatar from '../components/base/CommunityAvatar.vue'
 import CommunityBindingCard from './CommunityBindingCard.vue'
 import CommunityBlocks from './CommunityBlocks.vue'
 import CommunityPostMenu from './CommunityPostMenu.vue'
+import { blocksToMarkdown, blocksToText, copyText, downloadText, exportWatermark, safeFileBase, type ExportMeta } from './contentExport'
 import { postLabels, badgeLabels, relativeTime } from './labels'
 const props = defineProps<{ post: CommunityPostSummaryDto; detail?: boolean; requestId?: string; showPin?: boolean; pinned?: boolean }>()
 const emit = defineEmits<{ changed: []; hidden: [id: string]; pin: [id: string | null] }>()
@@ -25,6 +26,26 @@ const unpublish = () => act(async () => { await communityApi.unpublish(props.pos
 const report = () => act(async () => { await communityApi.report(props.post.id, reason.value, description.value); reportOpen.value = false })
 const edit = () => act(async () => { const post = await communityApi.post(props.post.id); store.openComposer({ expectedRevision: post.revision, type: post.type, title: post.title || '', contentBlocks: post.contentBlocks, bindings: post.bindings.filter((b) => b.status !== 'unavailable').map((b) => ({ type: b.type, id: b.id })), topicIds: post.topics.map((t) => t.id), visibility: post.visibility, status: post.status === 'draft' ? 'draft' : 'published', contribution: post.contribution ? { kind: post.contribution.kind, categoryId: post.contribution.categoryId, tags: post.contribution.tags, teachingReuseConsent: post.contribution.teachingReuseConsent, sourceName: post.contribution.sourceName, sourceUrl: post.contribution.sourceUrl, videoAssetId: post.contribution.videoAssetId, attachmentFileId: post.contribution.attachmentFileId, coverFileId: post.contribution.coverFileId } : undefined }, post.id) })
 const openPost = () => { void communityApi.signals({ eventType: 'community_post_click', targetType: 'post', targetId: props.post.id, requestId: props.requestId }).catch(() => undefined) }
+const copied = ref(false), downloadOpen = ref(false)
+let copiedTimer: ReturnType<typeof setTimeout> | undefined
+const exportMeta = computed<ExportMeta>(() => ({ author: props.post.author.displayName, origin: props.post.title || '社区帖子', link: `/community/post/${props.post.id}` }))
+const wholeText = computed(() => [props.post.title || '', blocksToText(props.post.contentBlocks)].filter(Boolean).join('\n\n'))
+const wholeMarkdown = computed(() => [`# ${props.post.title || '社区帖子'}`, '', `> ${exportWatermark({ author: props.post.author.displayName, origin: props.post.title || '社区帖子' }).join(' · ')}`, '', blocksToMarkdown(props.post.contentBlocks)].join('\n\n'))
+const copyWholePost = async () => {
+  if (!await copyText(wholeText.value)) return
+  copied.value = true
+  clearTimeout(copiedTimer)
+  copiedTimer = setTimeout(() => { copied.value = false }, 1800)
+}
+const downloadPost = (format: 'txt' | 'md') => {
+  const base = `${safeFileBase(props.post.author.displayName)}-${safeFileBase(props.post.title || props.post.id)}`
+  if (format === 'md') downloadText(`${base}.md`, wholeMarkdown.value, 'text/markdown;charset=utf-8')
+  else downloadText(`${base}.txt`, [...exportWatermark(exportMeta.value), '————————————', wholeText.value].join('\n'))
+  downloadOpen.value = false
+}
+const onDocClick = (event: MouseEvent) => { if (downloadOpen.value && !(event.target as HTMLElement).closest('.community-post-download')) downloadOpen.value = false }
+onMounted(() => { if (typeof document !== 'undefined' && typeof document.addEventListener === 'function') document.addEventListener('click', onDocClick) })
+onBeforeUnmount(() => { if (typeof document !== 'undefined' && typeof document.removeEventListener === 'function') document.removeEventListener('click', onDocClick); clearTimeout(copiedTimer) })
 const bodyClick = (event: MouseEvent) => {
   if (props.detail || (event.target as HTMLElement).closest('a, button, input, textarea, select, pre, code') || window.getSelection()?.toString()) return
   openPost(); void router.push(`/community/post/${props.post.id}`)
@@ -40,7 +61,7 @@ const bindingClick = (binding: CommunityBindingDto) => {
   <header class="community-post-header"><RouterLink class="author-avatar-link" :to="`/community/user/${post.author.username}`"><CommunityAvatar :src="post.author.avatar" :username="post.author.username" :name="post.author.displayName" /></RouterLink><div class="community-author"><RouterLink :to="`/community/user/${post.author.username}`"><strong>{{ post.author.displayName }}</strong><span v-if="post.author.verifiedType !== 'none'" class="community-badge">{{ badgeLabels[post.author.verifiedType] }}</span></RouterLink><small>{{ post.author.school || post.author.major || '学习社区' }} · <RouterLink class="community-post-time" :to="`/community/post/${post.id}`" :title="new Date(post.publishedAt).toLocaleString('zh-CN')" @click="openPost">{{ relativeTime(post.publishedAt) }}</RouterLink><span v-if="post.editedAt"> · 已编辑</span></small></div><span class="community-type" :class="post.type">{{ postLabels[post.type] }}</span><CommunityPostMenu><button v-if="post.author.id !== auth.user?.id" type="button" role="menuitem" :disabled="store.operations[`follow:user:${post.author.id}`]" @click="act(() => store.follow(post.author.id, false, !followingAuthor, undefined, post), false)">{{ followingAuthor ? '取消关注' : '关注作者' }}</button><template v-if="post.author.id === auth.user?.id"><button v-if="showPin && post.status === 'published' && post.visibility === 'public'" type="button" role="menuitem" @click="$emit('pin', pinned ? null : post.id)">{{ pinned ? '取消置顶' : '置顶到个人主页' }}</button><button type="button" role="menuitem" @click="edit">编辑动态</button><button v-if="post.contribution && post.status === 'published'" type="button" role="menuitem" @click="unpublishOpen = true">下架为草稿</button><button type="button" role="menuitem" @click="deleteOpen = true">删除动态</button></template><button type="button" role="menuitem" @click="hide('hide')">隐藏此内容</button><button type="button" role="menuitem" @click="hide('not-interested')">减少此类内容</button><template v-if="post.author.id !== auth.user?.id"><button type="button" role="menuitem" @click="hide('mute')">静音作者</button><button type="button" role="menuitem" @click="hide('block')">屏蔽作者</button></template><button type="button" role="menuitem" @click="reportOpen = true">举报内容</button></CommunityPostMenu></header>
   <div v-if="post.question" class="question-state"><span :class="{ solved: post.question.status === 'solved' }"><AppIcon v-if="post.question.status === 'solved'" name="check" :size="14" />{{ post.question.status === 'solved' ? '已解决' : '等待回答' }}</span><small v-if="post.question.teacherAnswered">认证教师参与回答</small></div>
   <h2 v-if="post.title" class="community-post-title"><RouterLink :to="`/community/post/${post.id}`" @click="openPost">{{ post.title }}</RouterLink></h2>
-  <div :class="{ 'community-post-body': !detail }" @click="bodyClick"><CommunityBlocks :blocks="post.contentBlocks" :compact="!detail && !expanded" @overflow="overflowed = $event" /></div>
+  <div :class="{ 'community-post-body': !detail }" @click="bodyClick"><CommunityBlocks :blocks="post.contentBlocks" :compact="!detail && !expanded" :author="post.author.displayName" :origin="post.title || '社区动态'" @overflow="overflowed = $event" /></div>
   <button v-if="!detail && (overflowed || expanded)" class="text-link" type="button" @click="toggleExpanded">{{ expanded ? '收起' : '展开全文' }}</button>
   <div class="community-bindings"><CommunityBindingCard v-for="binding in post.bindings" :key="`${binding.type}:${binding.id}`" :binding="binding" @click="binding.route && bindingClick(binding)" /></div>
   <div class="community-topic-list"><RouterLink v-for="topic in post.topics" :key="topic.id" :to="`/community/topic/${topic.slug}`"># {{ topic.name }}</RouterLink><span v-if="post.visibility === 'school'" class="muted">仅同校可见</span><span v-if="post.status === 'draft'" class="muted">私人草稿</span></div>
@@ -50,6 +71,8 @@ const bindingClick = (binding: CommunityBindingDto) => {
     <button :class="{ selected: post.viewerState.liked }" :aria-pressed="post.viewerState.liked" :aria-label="`点赞 ${post.stats.likes}`" :disabled="store.operations[`${post.id}:like`]" @click="reaction('like')"><AppIcon name="heart" :size="18" /><span>{{ post.stats.likes || '点赞' }}</span></button>
     <button :class="{ selected: post.viewerState.markedUseful }" :aria-pressed="post.viewerState.markedUseful" :aria-label="`有帮助 ${post.stats.useful}`" :disabled="store.operations[`${post.id}:useful`]" @click="reaction('useful')"><AppIcon name="check" :size="18" /><span>{{ post.stats.useful || '有帮助' }}</span></button>
     <button :class="{ selected: post.viewerState.bookmarked }" :aria-pressed="post.viewerState.bookmarked" :aria-label="`收藏 ${post.stats.bookmarks}`" :disabled="store.operations[`${post.id}:bookmark`]" @click="reaction('bookmark')"><AppIcon name="bookmark" :size="18" /><span>{{ post.stats.bookmarks || '收藏' }}</span></button>
+    <button type="button" class="text-link" aria-label="复制帖子全文" @click="copyWholePost"><AppIcon name="git" :size="15" /><span>{{ copied ? '已复制全文' : '复制全文' }}</span></button>
+    <details class="community-post-download content-export" :open="downloadOpen" @toggle="downloadOpen = ($event.target as HTMLDetailsElement).open"><summary aria-label="下载帖子"><AppIcon name="download" :size="15" />下载<AppIcon name="chevron-down" :size="12" /></summary><div class="content-export-menu"><button type="button" @click="downloadPost('txt')">纯文本 .txt</button><button type="button" @click="downloadPost('md')">Markdown .md</button></div></details>
   </footer><p v-if="error" class="community-error" role="alert">{{ error }}</p>
   <AppDialog v-model="reportOpen" title="举报内容"><form class="dialog-form" @submit.prevent="report"><label>举报原因<select v-model="reason"><option>内容不准确</option><option>不当内容或骚扰</option><option>泄露个人信息</option><option>垃圾广告</option><option>版权问题</option></select></label><label>补充说明<textarea v-model="description" maxlength="1000" rows="3" /></label><p>举报信息仅供有权限的审核人员处理，不向作者公开。</p><button class="button primary" :disabled="pending">提交举报</button></form></AppDialog>
   <AppDialog v-model="unpublishOpen" title="下架自己的资源作品"><p>作品将从资源中心、社区、作者页和合集公开入口撤下，并保留为私人草稿，之后仍可编辑并重新发布。</p><button class="button primary" :disabled="pending" @click="unpublish">确认下架</button></AppDialog>

--- a/frontend/src/community/contentExport.ts
+++ b/frontend/src/community/contentExport.ts
@@ -1,0 +1,43 @@
+import type { CommunityContentBlock } from '@ai-learning-hub/contracts'
+
+export interface ExportMeta { author?: string; origin?: string; link?: string }
+
+export const safeFileBase = (value: string) => (value.replace(/[\\/:*?"<>|\s]+/g, '-').replace(/^-+|-+$/g, '').slice(0, 60)) || 'community'
+
+export const exportWatermark = (meta: ExportMeta) => [
+  '来源：AI 数智化学习平台 · 题盒社区',
+  `作者：${meta.author || '社区学习者'}`,
+  meta.origin ? `出处：${meta.origin}` : '',
+  meta.link ? `链接：${meta.link}` : '',
+  `下载时间：${new Date().toLocaleString('zh-CN')}`,
+].filter((line): line is string => !!line)
+
+export const blocksToText = (blocks: CommunityContentBlock[]) => blocks.map((block) => {
+  if (block.type === 'code') return `${block.language || 'text'}：\n${block.code}`
+  if (block.type === 'image') return `[图片：${block.alt || '未命名图片'}]`
+  return block.text
+}).join('\n\n')
+
+export const blocksToMarkdown = (blocks: CommunityContentBlock[]) => blocks.map((block) => {
+  if (block.type === 'code') return ['```' + (block.language || 'text'), block.code, '```'].join('\n')
+  if (block.type === 'image') return `> [图片：${block.alt || '未命名图片'}]`
+  return block.text
+}).join('\n\n')
+
+export const copyText = async (text: string) => {
+  try {
+    await navigator.clipboard.writeText(text)
+    return true
+  } catch { return false }
+}
+
+export const downloadText = (name: string, content: string, type = 'text/plain;charset=utf-8') => {
+  const url = URL.createObjectURL(new Blob([content], { type }))
+  const anchor = document.createElement('a')
+  anchor.href = url
+  anchor.download = name
+  document.body.appendChild(anchor)
+  anchor.click()
+  anchor.remove()
+  URL.revokeObjectURL(url)
+}

--- a/frontend/src/styles/community/post.css
+++ b/frontend/src/styles/community/post.css
@@ -36,8 +36,20 @@
 .community-post-body { cursor: pointer; }
 .community-post-body pre, .community-post-body code { cursor: text; }
 .community-post-time { color: inherit; }
-.community-code { border: 1px solid var(--amc-border); border-radius: var(--amc-radius-control); background: var(--amc-bg-soft); margin: 12px 0; overflow: hidden; }
-.community-code small { display: block; padding: 8px 12px; border-bottom: 1px solid var(--amc-border); color: var(--amc-text-secondary); font-size: 12px; }
+.community-code { position: relative; border: 1px solid var(--amc-border); border-radius: var(--amc-radius-control); background: var(--amc-bg-soft); margin: 12px 0; overflow: visible; }
+.community-code-head { display: flex; align-items: center; justify-content: space-between; gap: 10px; padding: 5px 8px 5px 12px; border-bottom: 1px solid var(--amc-border); }
+.community-code-head small { color: var(--amc-text-secondary); font-size: 12px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.community-code-actions { display: inline-flex; align-items: center; gap: 6px; flex-shrink: 0; }
+.community-code-copy, .community-code-download summary { display: inline-flex; align-items: center; gap: 4px; min-height: 26px; padding: 4px 10px; border: 1px solid var(--amc-border); border-radius: var(--amc-radius-control); background: var(--amc-surface); color: var(--amc-text-secondary); font-size: 12px; white-space: nowrap; cursor: pointer; transition: color var(--amc-duration-control) var(--amc-ease), background var(--amc-duration-control) var(--amc-ease), border-color var(--amc-duration-control) var(--amc-ease); }
+.community-code-copy:hover, .community-code-download summary:hover { border-color: var(--amc-orange-border); background: var(--amc-orange-soft); color: var(--amc-orange); }
+.community-code-copy.is-copied { color: var(--amc-success); }
+.community-code-copy.is-failed { color: var(--amc-error); }
+.community-code-download { position: relative; }
+.community-code-download summary { list-style: none; }
+.community-code-download summary::-webkit-details-marker { display: none; }
+.community-code-menu { position: absolute; top: calc(100% + 6px); right: 0; z-index: 20; display: grid; min-width: 150px; padding: 6px; border: 1px solid var(--amc-border); border-radius: var(--amc-radius-control); background: var(--amc-surface); box-shadow: var(--amc-shadow-float); }
+.community-code-menu > button { display: block; width: 100%; min-height: 30px; padding: 5px 10px; border: 0; border-radius: var(--amc-radius-xs); background: none; color: var(--amc-text-body); font-size: 12px; text-align: left; white-space: nowrap; cursor: pointer; }
+.community-code-menu > button:hover { background: var(--amc-orange-soft); color: var(--amc-orange); }
 .community-code pre { overflow-x: auto; margin: 0; padding: 14px; font-size: 12px; line-height: 1.75; }
 .community-content.compact .community-code pre { max-height: 160px; }
 .community-bindings { display: grid; gap: 8px; margin: 14px 0; }

--- a/frontend/src/styles/components.css
+++ b/frontend/src/styles/components.css
@@ -93,6 +93,14 @@ textarea { resize: vertical; }
 .dialog-card label { display: grid; gap: 7px; color: var(--secondary); font-size: .8rem; font-weight: 700; }
 .dialog-title { display: flex; align-items: center; justify-content: space-between; gap: 18px; }
 .toast { position: fixed; right: 24px; bottom: 24px; z-index: 100; max-width: 410px; padding: 15px 18px; color: white; border-radius: 11px; background: #17222c; box-shadow: 0 18px 40px rgba(0,0,0,.22); font-size: .82rem; line-height: 1.55; }
+.content-export { position: relative; display: inline-block; }
+.content-export.full-width { width: 100%; }
+.content-export > summary { display: inline-flex; align-items: center; justify-content: center; gap: 5px; min-height: 30px; padding: 4px 10px; border: 1px solid var(--amc-border); border-radius: var(--amc-radius-control); background: var(--amc-surface); color: var(--amc-text-secondary); font-size: 12px; font-weight: 500; white-space: nowrap; cursor: pointer; list-style: none; transition: color var(--amc-duration-control) var(--amc-ease), background var(--amc-duration-control) var(--amc-ease), border-color var(--amc-duration-control) var(--amc-ease); }
+.content-export > summary::-webkit-details-marker { display: none; }
+.content-export > summary:hover { border-color: var(--amc-orange-border); background: var(--amc-orange-soft); color: var(--amc-orange); }
+.content-export-menu { position: absolute; top: calc(100% + 6px); right: 0; z-index: 20; display: grid; min-width: 150px; padding: 6px; border: 1px solid var(--amc-border); border-radius: var(--amc-radius-control); background: var(--amc-surface); box-shadow: var(--amc-shadow-float); }
+.content-export-menu > button { display: block; width: 100%; min-height: 30px; padding: 5px 10px; border: 0; border-radius: var(--amc-radius-xs); background: none; color: var(--amc-text-body); font-size: 12px; text-align: left; white-space: nowrap; cursor: pointer; }
+.content-export-menu > button:hover { background: var(--amc-orange-soft); color: var(--amc-orange); }
 .app-dialog {
   width: 100%;
   max-width: none;

--- a/frontend/src/styles/pages/courses.css
+++ b/frontend/src/styles/pages/courses.css
@@ -6,6 +6,7 @@
 .teacher small { color: var(--muted); }
 .teacher .button { margin-left: 8px; }
 .hero-progress { display: flex; flex-direction: column; gap: 15px; padding: 21px; border: 1px solid var(--border); border-radius: var(--radius-card); background: white; box-shadow: var(--shadow); }
+.hero-progress .content-export > summary { width: 100%; min-height: 42px; font-size: .9rem; font-weight: 600; }
 .learning-layout { display: grid; grid-template-columns: 240px minmax(0, 1fr) 270px; align-items: start; gap: 20px; }
 .sticky { position: sticky; top: 92px; }
 .outline-title { display: flex; justify-content: space-between; width: 100%; min-height: 42px; border: 0; background: transparent; cursor: pointer; }

--- a/frontend/src/views/CourseView.vue
+++ b/frontend/src/views/CourseView.vue
@@ -3,7 +3,7 @@ import CommunityAvatar from '../components/base/CommunityAvatar.vue'
 import FollowButton from '../components/base/FollowButton.vue'
 import type { CourseDetailDto } from '@ai-learning-hub/contracts'
 import { storeToRefs } from 'pinia'
-import { computed, ref, watch } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import CourseCard from '../components/CourseCard.vue'
 import AppDialog from '../components/base/AppDialog.vue'
@@ -11,6 +11,7 @@ import AppIcon from '../components/base/AppIcon.vue'
 import NotFoundState from '../components/NotFoundState.vue'
 import ProgressBar from '../components/ProgressBar.vue'
 import CategoryCover from '../components/base/CategoryCover.vue'
+import { copyText, downloadText, exportWatermark, safeFileBase } from '../community/contentExport'
 import { dataMode } from '../services/api/client'
 import { useAuthStore } from '../stores/auth'
 import { mapCourse, useCoursesStore } from '../stores/content/courses'
@@ -79,6 +80,37 @@ const copyCode = async () => {
 const saveNote = async () => {
   if (await store.saveNote(courseId.value, noteDraft.value, dataMode === 'api' ? currentApiLesson.value?.id : undefined)) noteOpen.value = false
 }
+const instructorName = computed(() => courseDetail.value?.data.instructor?.name || (dataMode === 'api' ? '课程讲师' : '林知远老师'))
+const overviewLines = computed(() => [
+  `${course.value?.title || '课程'}（${course.value?.category || '课程'} · ${course.value?.level || '入门'}）`,
+  course.value?.description || '',
+  `讲师：${instructorName.value}`,
+  `共 ${displayLessons.value.length} 课时：`,
+  ...displayLessons.value.map((lesson, index) => `${index + 1}. ${lesson}`),
+])
+const courseCopied = ref(false), exportOpen = ref(false)
+let courseCopiedTimer: ReturnType<typeof setTimeout> | undefined
+const copyOverview = async () => {
+  if (!course.value || !await copyText(overviewLines.value.join('\n'))) return
+  courseCopied.value = true
+  clearTimeout(courseCopiedTimer)
+  courseCopiedTimer = setTimeout(() => { courseCopied.value = false }, 1800)
+}
+const exportCourse = (format: 'txt' | 'md') => {
+  if (!course.value) return
+  const meta = { author: instructorName.value, origin: course.value.title }
+  const base = `${safeFileBase(instructorName.value)}-${safeFileBase(course.value.title)}-课程速览`
+  if (format === 'md') {
+    const markdown = [`# ${course.value.title}`, '', `> ${exportWatermark(meta).join(' · ')}`, '', course.value.description || '', '', ...displayLessons.value.map((lesson, index) => `${index + 1}. ${lesson}`), '', '示例代码：', '', '```python', code, '```'].join('\n')
+    downloadText(`${base}.md`, markdown, 'text/markdown;charset=utf-8')
+  } else {
+    downloadText(`${base}.txt`, [...exportWatermark(meta), '————————————', ...overviewLines.value, '', '示例代码：', code].join('\n'))
+  }
+  exportOpen.value = false
+}
+const onDocClick = (event: MouseEvent) => { if (exportOpen.value && !(event.target as HTMLElement).closest('.content-export')) exportOpen.value = false }
+onMounted(() => { if (typeof document !== 'undefined' && typeof document.addEventListener === 'function') document.addEventListener('click', onDocClick) })
+onBeforeUnmount(() => { if (typeof document !== 'undefined' && typeof document.removeEventListener === 'function') document.removeEventListener('click', onDocClick); clearTimeout(courseCopiedTimer) })
 const shareNote = () => { if (!ensureAuth('登录后可主动分享学习笔记', shareNote)) return; useCommunityStore().openComposer({ type: 'note', title: `${course.value?.title || '课程'}学习笔记`, contentBlocks: [{ type: 'paragraph', text: store.notes[noteKey.value] || noteDraft.value }], bindings: [{ type: 'course', id: courseId.value }, ...(currentApiLesson.value ? [{ type: 'lesson' as const, id: currentApiLesson.value.id }] : [])] }) }
 const completeCurrentLesson = () => {
   const lessonId = dataMode === 'api' ? currentApiLesson.value?.id : currentLesson.value
@@ -117,7 +149,7 @@ watch(courseId, async () => {
     <section class="course-hero">
       <div class="hero-copy"><span class="tag purple">{{ course.category }}</span><h1>{{ course.title }}</h1><p>{{ course.description }}{{ dataMode === 'mock' ? ' 从核心概念出发，逐步走向受控实践。' : '' }}</p><div class="meta"><span>{{ course.level }}</span><span>{{ chapterCount }} 章 · {{ displayLessons.length }} 节</span><span>{{ course.learners === undefined ? '学习人数 —' : `${course.learners.toLocaleString()} 人学习` }}</span><span>{{ dataMode === 'api' ? (courseDetail?.data.rating ? `${courseDetail.data.rating} 分` : '评分 —') : '4.9 分' }}</span></div><div class="teacher"><CommunityAvatar :name="courseDetail?.data.instructor?.name || '讲师'" :avatar-key="dataMode === 'mock' ? 'official-teacher' : undefined" /><div><strong>{{ courseDetail?.data.instructor?.name || (dataMode === 'api' ? '讲师待配置' : '林知远老师') }}</strong><small>{{ courseDetail?.data.instructor?.title || (dataMode === 'api' ? '信息待配置' : '高校 AI 应用课程讲师') }}</small></div><FollowButton v-if="dataMode === 'mock'" :active="followed" @click="followed = !followed" /></div></div>
       <CategoryCover :title="course.title" :media="course" eager />
-      <aside class="hero-progress"><ProgressBar v-if="accountDataReady" :value="store.courseProgress[course.id] ?? course.progress ?? 0" label="学习进度" /><p v-else class="notice">{{ accountDataMessage }}</p><strong>当前第 {{ currentLesson }} / {{ displayLessons.length }} 课时</strong><button class="button primary full-width" type="button" :disabled="!displayLessons.length" @click="startLearning()">{{ store.courseProgress[course.id] ? '继续学习' : '开始学习' }}</button><button class="button secondary full-width" type="button" :disabled="!displayLessons.length" @click="completeCurrentLesson">完成本节</button><button class="button secondary full-width" type="button" @click="store.toggleFavorite('course', course.id)">{{ store.isFavorite('course', course.id) ? '已收藏' : '收藏课程' }}</button></aside>
+      <aside class="hero-progress"><ProgressBar v-if="accountDataReady" :value="store.courseProgress[course.id] ?? course.progress ?? 0" label="学习进度" /><p v-else class="notice">{{ accountDataMessage }}</p><strong>当前第 {{ currentLesson }} / {{ displayLessons.length }} 课时</strong><button class="button primary full-width" type="button" :disabled="!displayLessons.length" @click="startLearning()">{{ store.courseProgress[course.id] ? '继续学习' : '开始学习' }}</button><button class="button secondary full-width" type="button" :disabled="!displayLessons.length" @click="completeCurrentLesson">完成本节</button><button class="button secondary full-width" type="button" @click="store.toggleFavorite('course', course.id)">{{ store.isFavorite('course', course.id) ? '已收藏' : '收藏课程' }}</button><button class="button secondary full-width" type="button" @click="copyOverview">{{ courseCopied ? '已复制速览' : '复制课程速览' }}</button><details class="content-export full-width" :open="exportOpen" @toggle="exportOpen = ($event.target as HTMLDetailsElement).open"><summary aria-label="下载课程速览"><AppIcon name="download" :size="14" />下载课程速览<AppIcon name="chevron-down" :size="12" /></summary><div class="content-export-menu"><button type="button" @click="exportCourse('txt')">纯文本 .txt</button><button type="button" @click="exportCourse('md')">Markdown .md</button></div></details></aside>
     </section>
     <RouterLink class="text-link" :to="`/community/search?bindingId=${courseId}`">查看课程相关讨论 <AppIcon name="arrow-up-right" :size="14" /></RouterLink>
     <div class="learning-layout">


### PR DESCRIPTION
## 背景

学生发实训报告常贴命令、报错与配置，看帖的人需要把内容一键带走去终端验证——这是掘金、GitHub、知乎等技术社区的标配动作。此前代码块只能手动划选复制，整篇帖子 / 课程内容没有任何导出能力。本 PR 为社区与课程补充"复制 + 下载"能力，所有下载文件自动携带作者水印。

## 新增功能

### 1. 代码块一键复制 + 三格式下载（全站生效）
- `CommunityBlocks.vue`（帖子正文与评论共用的渲染组件，改一处全站生效）
- 代码块头部右侧新增「复制」按钮：点击复制代码全文，"已复制"（成功绿）/ "复制失败，请手动选择" 1.8s 恢复；多代码块按 index 独立状态、互不干扰
- 新增「下载 ▾」菜单，三种格式：
  - **纯文本 .txt**：水印头 + 代码全文
  - **Markdown .md**：可见出处引用行 + 围栏代码
  - **源码文件 .py/.sh/.js/.ts/.go/.rs/.sql/.yml…**（按语言映射 30+ 种扩展名，未知语言降级 .txt）：按语言选择注释前缀（`#` / `//` / `--`）逐行写入水印
- 按钮绝对定位于代码块右上角，不随代码横向滚动移位；compact 折叠态保留（复制全文不受折叠影响）

### 2. 帖子级复制全文 + 下载（任何人的帖子）
- `CommunityPostCard.vue` 底部操作栏新增「复制全文」「下载 ▾」——信息流卡片、帖子详情、收藏、个人页等所有帖子渲染处通用
- 复制全文：标题 + 全部正文/代码一键进剪贴板
- 下载 TXT / Markdown：整帖内容（段落、代码、图片占位说明），文件名 `{作者}-{标题}.txt/.md`

### 3. 课程速览导出（CourseView）
- 课程页右栏新增「复制课程速览」「下载课程速览」（TXT / Markdown）
- 内容：课程名、分类级别、简介、讲师、全部课时列表、示例代码

### 4. 作者水印（所有下载文件必带）
```
来源：AI 数智化学习平台 · 题盒社区
作者：{发帖人 / 评论人 / 课程讲师}
出处：{帖子标题 / 课程名}
链接：{帖子路由}（帖子下载）
下载时间：{本地时间}
```
- Markdown 中为可见引用行，TXT 为文件头，源码文件为对应语法的注释头
- 文件名含作者名，非法字符已过滤；水印数据由调用方传入（帖子卡片→帖子作者，评论区→评论作者，课程→讲师），字段缺失降级为"社区学习者"，不伪造

### 5. 通用工具 contentExport.ts
- 水印生成、blocks→纯文本 / Markdown 转换、剪贴板、Blob 下载集中一处，帖子与课程共用，后续页面可复用

## 边界与不变承诺

- 不动发帖接口、数据结构与草稿/乐观锁逻辑，纯前端能力
- 不加行号、不做代码高亮、不引入任何第三方库
- 全部配色走 tokens 现有变量（含成功/错误色），零新增色值
- 菜单外点关闭使用防御式守卫（`typeof document !== 'undefined'`），非浏览器测试环境安全跳过

## 验证

- `npm run lint` ✅
- `npm run typecheck`（vue-tsc）✅
- `vitest run` 全量 166/167（唯一失败为 `learning.api.test.ts` 5s 超时，与本改动无关，单测通过）
- `VITE_DATA_MODE=api npm run build` ✅
