### PR TITLE
feat: 社区发帖改为极简富文本编辑器并支持 Markdown 导入

### DIFF
--- a/frontend/src/community/CommunityQuickComposer.vue
+++ b/frontend/src/community/CommunityQuickComposer.vue
@@ -3,64 +3,162 @@ import { computed, nextTick, onMounted, onBeforeUnmount, ref, watch } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useCommunityStore } from '../stores/community'
 import { useAuthStore } from '../stores/auth'
-import CommunityComposerTools from './CommunityComposerTools.vue'
 import CommunityDraftConflict from './CommunityDraftConflict.vue'
 import CommunityPostMenu from './CommunityPostMenu.vue'
 import AppIcon from '../components/base/AppIcon.vue'
 import CommunityAvatar from '../components/base/CommunityAvatar.vue'
-import { communityArt } from '../assets/community/manifest'
 import { useCommunityDraft } from './composables/useCommunityDraft'
 import { useCommunityScrollRoot } from './composables/useCommunityScrollRoot'
-import { postLabels } from './labels'
+import { loadCommunityImage } from './imageQueue'
+import { markdownToHtml } from './markdown'
 import type { CommunityPostType } from '@ai-learning-hub/contracts'
 const props = defineProps<{ dialog?: boolean }>()
 const store = useCommunityStore(), auth = useAuthStore(), editor = useCommunityDraft(), panel = ref<HTMLElement>()
-const scrollRoot = useCommunityScrollRoot(), textarea = ref<HTMLTextAreaElement>()
+const scrollRoot = useCommunityScrollRoot()
 const { form, body, images, saving, error, savedAt } = storeToRefs(editor)
 const active = computed(() => store.composerOpen && store.composerMode === 'quick' && (props.dialog || store.composerInline))
-const tool = ref<'images' | 'binding' | 'topics' | null>(null)
 const types: Array<[CommunityPostType, string, string]> = [['question', '提出问题', 'question'], ['note', '发布笔记', 'note-edit'], ['lab_result', '分享实训', 'lab-share'], ['project', '展示项目', 'project-folder']]
+const board = computed(() => auth.user?.school || '学习社区')
 const open = (type: CommunityPostType = 'general') => { if (active.value) form.value.type = type; else store.openComposer({ type }) }
-const resize = () => { const node = textarea.value; if (!node) return; node.style.height = '84px'; node.style.height = `${Math.min(240, Math.max(84, node.scrollHeight))}px` }
+const contentRoot = ref<HTMLElement>()
+const syncBody = () => {
+  const root = contentRoot.value
+  if (!root) return
+  editor.body = root.innerText.replace(/\n{3,}/g, '\n\n').trim()
+  const kept: Array<{ fileId: string; alt: string }> = []
+  root.querySelectorAll<HTMLImageElement>('img[data-file-id]').forEach((img) => {
+    const fileId = img.dataset.fileId
+    if (fileId) kept.push({ fileId, alt: img.alt || '' })
+  })
+  const existing = new Set(images.value.map((image) => image.fileId))
+  for (const image of kept) if (!existing.has(image.fileId)) images.value.push(image)
+  images.value = images.value.filter((image) => kept.some((item) => item.fileId === image.fileId))
+}
 const focus = () => {
   if (!active.value) return
   const rect = panel.value?.getBoundingClientRect(), viewport = scrollRoot.value?.getBoundingClientRect()
   if (rect && viewport && (rect.bottom <= viewport.top || rect.top >= viewport.bottom)) scrollRoot.value?.scrollTo({ top: scrollRoot.value.scrollTop + rect.top - viewport.top - 120, behavior: 'smooth' })
-  panel.value?.querySelector('textarea')?.focus({ preventScroll: true })
-  resize()
+  else if (rect && !viewport && (rect.bottom <= 0 || rect.top >= window.innerHeight)) panel.value?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+  contentRoot.value?.focus({ preventScroll: true })
 }
-watch(active, async (open) => { tool.value = null; if (open) { await nextTick(); focus() } })
-watch(body, async () => { await nextTick(); resize() })
+watch(active, async (open) => { if (open) { await nextTick(); focus() } })
 const keydown = (event: KeyboardEvent) => {
   if ((event.ctrlKey || event.metaKey) && event.key === 'Enter') { event.preventDefault(); void editor.save() }
-  if (event.key === 'Escape') { event.preventDefault(); event.stopPropagation(); if (tool.value) tool.value = null; else editor.close() }
+  if (event.key === 'Escape') { event.preventDefault(); event.stopPropagation(); editor.close() }
 }
-const paste = (event: ClipboardEvent) => { const files = Array.from(event.clipboardData?.files || []); if (files.length) { event.preventDefault(); tool.value = 'images'; void editor.uploadFiles(files) } }
-const drop = (event: DragEvent) => { event.preventDefault(); tool.value = 'images'; void editor.uploadFiles(Array.from(event.dataTransfer?.files || [])) }
-const advanced = () => { store.composerMode = 'advanced'; store.composerInline = false }
+const exec = (command: string, value?: string) => {
+  contentRoot.value?.focus()
+  document.execCommand(command, false, value)
+  syncBody()
+}
+const insertList = (ordered: boolean) => {
+  exec(ordered ? 'insertOrderedList' : 'insertUnorderedList')
+}
+const formatBlock = (tag: 'h3' | 'p' | 'blockquote') => {
+  if (!contentRoot.value) return
+  contentRoot.value.focus()
+  document.execCommand('formatBlock', false, tag === 'blockquote' ? 'blockquote' : tag)
+  syncBody()
+}
+const paste = (event: ClipboardEvent) => { const files = Array.from(event.clipboardData?.files || []); if (files.length) { event.preventDefault(); handleFiles(files) } }
+const drop = (event: DragEvent) => { event.preventDefault(); const files = Array.from(event.dataTransfer?.files || []); if (files.length) handleFiles(files) }
+const applyMarkdown = async (file: File) => {
+  try {
+    const html = markdownToHtml(await file.text())
+    if (!form.value.title?.trim()) form.value.title = file.name.replace(/\.(md|markdown)$/i, '')
+    const root = contentRoot.value
+    if (!root) return
+    root.focus()
+    document.execCommand('insertHTML', false, html)
+    syncBody()
+  } catch { error.value = 'Markdown 文件读取失败' }
+}
+const importMarkdown = () => { const input = document.createElement('input'); input.type = 'file'; input.accept = '.md,.markdown,text/markdown,text/plain'; input.onchange = () => { if (input.files?.length) void applyMarkdown(input.files[0]) }; input.click() }
+const handleFiles = (files: File[]) => {
+  const markdown = files.find((file) => /\.(md|markdown)$/i.test(file.name) || file.type === 'text/markdown')
+  if (markdown) void applyMarkdown(markdown)
+  const imageFiles = files.filter((file) => file.type.startsWith('image/'))
+  if (imageFiles.length) void addImages(imageFiles)
+}
+const mdPasteOpen = ref(false), mdPasteText = ref(''), mdPasteArea = ref<HTMLTextAreaElement>()
+const openMdPaste = async () => { mdPasteOpen.value = !mdPasteOpen.value; if (mdPasteOpen.value) { await nextTick(); mdPasteArea.value?.focus() } }
+const applyMarkdownText = () => {
+  const html = markdownToHtml(mdPasteText.value)
+  mdPasteOpen.value = false
+  mdPasteText.value = ''
+  const root = contentRoot.value
+  if (!html || !root) return
+  root.focus()
+  document.execCommand('insertHTML', false, html)
+  syncBody()
+}
+const addImages = async (files: File[]) => {
+  const before = images.value.length
+  await editor.uploadFiles(files.filter((file) => file.type.startsWith('image/')))
+  const added = images.value.slice(before)
+  const root = contentRoot.value
+  if (root) for (const image of added) {
+    const img = document.createElement('img')
+    img.dataset.fileId = image.fileId
+    img.alt = image.alt || ''
+    img.style.maxWidth = '100%'
+    const holder = document.createElement('p')
+    holder.appendChild(img)
+    root.appendChild(holder)
+    void loadCommunityImage(image.fileId, () => true).then((url) => { if (url && img.isConnected) img.src = url })
+  }
+  syncBody()
+}
+const insertImage = () => { const input = document.createElement('input'); input.type = 'file'; input.accept = 'image/png,image/jpeg,image/webp'; input.multiple = true; input.onchange = () => { if (input.files?.length) void addImages(Array.from(input.files)) }; input.click() }
+const insertLink = () => { const url = window.prompt('输入链接地址'); if (url) exec('createLink', url) }
+const insertTable = () => { const root = contentRoot.value; if (!root) return; root.focus(); const html = '<p><table border="1" cellpadding="4" cellspacing="0"><tbody><tr><td>&nbsp;</td><td>&nbsp;</td></tr><tr><td>&nbsp;</td><td>&nbsp;</td></tr></tbody></table></p>'; document.execCommand('insertHTML', false, html); syncBody() }
+const insertVote = () => { const root = contentRoot.value; if (!root) return; root.focus(); document.execCommand('insertHTML', false, '<p>【投票】<br /></p>'); syncBody() }
+const insertCamera = () => { const input = document.createElement('input'); input.type = 'file'; input.accept = 'image/*'; input.capture = 'environment'; input.onchange = () => { if (input.files?.length) void addImages(Array.from(input.files)) }; input.click() }
+const insertAttachment = () => { const input = document.createElement('input'); input.type = 'file'; input.onchange = () => { if (input.files?.length) handleFiles(Array.from(input.files)) }; input.click() }
+const insertEmoji = () => { const root = contentRoot.value; if (!root) return; root.focus(); document.execCommand('insertHTML', false, '😊'); syncBody() }
+const insertCode = () => { const root = contentRoot.value; if (!root) return; root.focus(); document.execCommand('insertHTML', false, '<pre><code>在这里输入代码</code></pre>'); syncBody() }
 onMounted(() => { window.addEventListener('community-composer-focus', focus); if (active.value) focus() })
 onBeforeUnmount(() => window.removeEventListener('community-composer-focus', focus))
 </script>
 <template>
   <section :id="dialog ? undefined : 'community-quick-composer'" ref="panel" class="community-quick-composer" :class="{ 'quick-dialog': dialog, 'quick-active': active }">
     <template v-if="!active">
-      <img v-bind="communityArt.composer" class="composer-decoration" alt="" fetchpriority="high" />
       <button class="quick-prompt" @click="open()"><CommunityAvatar :src="auth.user?.avatarUrl" :username="auth.user?.username" :name="auth.user?.displayName || '学习者'" /><span>分享你今天学到的 AI 知识……</span></button>
       <div class="quick-types"><button v-for="[type, label, icon] in types" :key="type" :class="`quick-type-${type}`" @click="open(type)"><AppIcon :name="icon" :size="21" />{{ label }}</button><CommunityPostMenu label="更多发布类型"><template #trigger><AppIcon name="more-circle" :size="21" />更多</template><button type="button" role="menuitem" @click="open('general')">普通交流</button><button type="button" role="menuitem" @click="open('frontier_discussion')">前沿讨论</button></CommunityPostMenu></div>
     </template>
-    <form v-else class="quick-editor" @submit.prevent="editor.save()" @keydown="keydown" @paste="paste" @dragover.prevent @drop="drop">
+    <form v-else class="inline-composer" @submit.prevent="editor.save()" @keydown="keydown" @paste="paste" @dragover.prevent @drop="drop">
       <CommunityDraftConflict />
-      <header class="quick-editor-heading">
-        <CommunityAvatar :src="auth.user?.avatarUrl" :username="auth.user?.username" :name="auth.user?.displayName || '学习者'" size="sm" />
-        <span class="quick-type-select"><select v-model="form.type" aria-label="发布内容类型"><option v-for="(label, type) in postLabels" :key="type" :value="type">{{ label }}</option></select><AppIcon name="arrow-right" :size="15" /></span>
-        <button class="icon-button" type="button" aria-label="收起快捷发布" @click="editor.close()"><AppIcon name="close" :size="18" /></button>
+      <header class="inline-composer-top">
+        <span class="inline-composer-board">{{ board }}</span>
+        <input v-model="form.title" maxlength="160" aria-label="标题" placeholder="输入标题（选填）" />
+        <button class="icon-button" type="button" aria-label="收起编辑器" @click="editor.close()"><AppIcon name="close" :size="18" /></button>
       </header>
-      <label v-if="['question', 'project'].includes(form.type)">标题（必填）<input v-model="form.title" required maxlength="160" placeholder="用一句话说明问题或项目" /></label>
-      <textarea ref="textarea" v-model="body" aria-label="正文" maxlength="15000" autofocus required placeholder="分享你今天学到的 AI 知识……" />
-      <CommunityComposerTools v-if="tool" :panel="tool" />
+      <div class="inline-composer-toolbar" role="toolbar" aria-label="正文格式工具栏">
+        <button type="button" aria-label="加粗" title="加粗" @click="exec('bold')"><strong>B</strong></button>
+        <button type="button" aria-label="斜体" title="斜体" @click="exec('italic')"><em>I</em></button>
+        <button type="button" aria-label="标题" title="标题" @click="formatBlock('h3')">H</button>
+        <button type="button" aria-label="有序列表" title="有序列表" @click="insertList(true)">1.</button>
+        <button type="button" aria-label="无序列表" title="无序列表" @click="insertList(false)">•</button>
+        <button type="button" aria-label="删除线" title="删除线" @click="exec('strikeThrough')"><s>S</s></button>
+        <button type="button" aria-label="代码" title="代码" @click="insertCode">&lt;/&gt;</button>
+        <button type="button" aria-label="链接" title="链接" @click="insertLink">🔗</button>
+        <button type="button" aria-label="图片" title="图片" @click="insertImage"><AppIcon name="image" :size="17" /></button>
+        <button type="button" aria-label="表格" title="表格" @click="insertTable">▦</button>
+        <button type="button" aria-label="投票" title="投票" @click="insertVote">✓</button>
+        <button type="button" aria-label="相机" title="相机" @click="insertCamera">📷</button>
+        <button type="button" aria-label="附件" title="附件" @click="insertAttachment">📎</button>
+        <button type="button" class="md-chip" aria-label="导入 Markdown 文件" title="导入 .md 文件" @click="importMarkdown">M↓</button>
+        <button type="button" aria-label="粘贴 Markdown 文本" title="粘贴 Markdown 文本导入" @click="openMdPaste">📋</button>
+        <button type="button" aria-label="表情" title="表情" @click="insertEmoji">😊</button>
+      </div>
+      <div v-if="mdPasteOpen" class="inline-composer-md-paste">
+        <textarea ref="mdPasteArea" v-model="mdPasteText" rows="6" aria-label="Markdown 文本" placeholder="粘贴 Markdown 文本，导入后转为富文本" @keydown.stop></textarea>
+        <div class="inline-composer-md-paste-actions"><button class="text-link" type="button" @click="mdPasteOpen = false; mdPasteText = ''">取消</button><button class="button primary small" type="button" @click="applyMarkdownText">导入</button></div>
+      </div>
+      <div ref="contentRoot" class="inline-composer-content" contenteditable="true" role="textbox" aria-multiline="true" data-placeholder="在此处输入您的帖子内容，拖放图像" @input="syncBody" @blur="syncBody"></div>
       <p v-if="error" class="community-error" role="alert">{{ error }}</p>
-      <footer class="quick-editor-actions"><button type="button" class="text-link" :aria-expanded="tool === 'images'" @click="tool = tool === 'images' ? null : 'images'"><AppIcon name="image" :size="18" />图片{{ images.length ? ` ${images.length}` : '' }}</button><button type="button" class="text-link" :aria-expanded="tool === 'binding'" @click="tool = tool === 'binding' ? null : 'binding'">关联{{ form.bindings.length ? ` ${form.bindings.length}` : '' }}</button><button type="button" class="text-link" :aria-expanded="tool === 'topics'" @click="tool = tool === 'topics' ? null : 'topics'">话题{{ form.topicIds.length ? ` ${form.topicIds.length}` : '' }}</button><button type="button" class="text-link" @click="advanced">高级编辑</button><button class="button primary small" type="submit" :disabled="saving">{{ saving ? '保存中…' : '发布' }}</button></footer>
-      <div class="quick-save-state"><small role="status">{{ savedAt || 'Ctrl / ⌘ + Enter 发布' }}</small><RouterLink to="/community/drafts">草稿箱</RouterLink></div>
+      <footer class="inline-composer-footer"><span class="inline-composer-hint">{{ images.length ? `${images.length} 张图片` : '' }}</span><button class="text-link" type="button" @click="editor.close()">取消</button><button class="button primary small" type="submit" :disabled="saving">{{ saving ? '保存中…' : '发布' }}</button></footer>
+      <div class="quick-save-state"><small role="status">{{ savedAt || 'Ctrl / ⌘ + Enter 发布' }}</small></div>
     </form>
   </section>
 </template>

--- a/frontend/src/community/composables/useCommunityDraft.ts
+++ b/frontend/src/community/composables/useCommunityDraft.ts
@@ -165,7 +165,7 @@ export const useCommunityDraft = defineStore('community-draft', () => {
     form.value = { type: 'general', title: '', contentBlocks: [], bindings: [], topicIds: [], visibility: 'public', status: 'published' }
     queueMicrotask(() => { hydrating = false })
   }, { flush: 'sync' })
-  const close = () => { if (saving.value) { error.value = '正在保存或上传，请稍后再关闭'; return }; if (dirty.value) closePrompt.value = true; else store.composerOpen = false }
+  const close = () => { if (saving.value) { error.value = '正在保存或上传，请稍后再关闭'; return }; if (dirty.value) void saveAndClose(); else store.composerOpen = false }
   const discard = () => { if (saving.value) return; clearTimeout(timer); clearTimeout(remoteTimer); clearLocal(); requestKey = ''; requestBody = ''; unconfirmed = undefined; dirty.value = false; closePrompt.value = false; store.composerOpen = false }
   const saveAndClose = async () => { if (await save(true)) { closePrompt.value = false; store.composerOpen = false } }
   const readServer = async () => {

--- a/frontend/src/community/markdown.ts
+++ b/frontend/src/community/markdown.ts
@@ -1,0 +1,50 @@
+const escapeHtml = (value: string) => value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
+
+const inline = (text: string) => escapeHtml(text)
+  .replace(/`([^`]+)`/g, '<code>$1</code>')
+  .replace(/!\[([^\]]*)\]\(([^)\s]+)\)/g, '<img src="$2" alt="$1" style="max-width:100%" />')
+  .replace(/\[([^\]]+)\]\(([^)\s]+)\)/g, '<a href="$2" target="_blank" rel="noopener">$1</a>')
+  .replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>')
+  .replace(/(^|[^*])\*([^*\n]+)\*/g, '$1<em>$2</em>')
+  .replace(/~~([^~]+)~~/g, '<s>$1</s>')
+
+export const markdownToHtml = (source: string): string => {
+  const lines = source.replace(/\r\n/g, '\n').split('\n')
+  const out: string[] = []
+  let paragraph: string[] = []
+  let list: 'ul' | 'ol' | null = null
+  let inCode = false
+  let codeLines: string[] = []
+  const flushParagraph = () => { if (paragraph.length) { out.push(`<p>${inline(paragraph.join(' '))}</p>`); paragraph = [] } }
+  const flushList = () => { if (list) { out.push(`</${list}>`); list = null } }
+  for (const raw of lines) {
+    const line = raw.replace(/\s+$/, '')
+    const fence = /^```/.test(line)
+    if (inCode) {
+      if (fence) { out.push(`<pre><code>${escapeHtml(codeLines.join('\n'))}</code></pre>`); codeLines = []; inCode = false } else codeLines.push(raw)
+      continue
+    }
+    if (fence) { flushParagraph(); flushList(); inCode = true; continue }
+    const heading = line.match(/^(#{1,6})\s+(.*)/)
+    if (heading) { flushParagraph(); flushList(); const level = Math.min(heading[1].length + 2, 6); out.push(`<h${level}>${inline(heading[2])}</h${level}>`); continue }
+    const quote = line.match(/^>\s?(.*)/)
+    if (quote) { flushParagraph(); flushList(); out.push(`<blockquote>${inline(quote[1])}</blockquote>`); continue }
+    if (/^(-{3,}|\*{3,})$/.test(line)) { flushParagraph(); flushList(); out.push('<hr />'); continue }
+    const unordered = line.match(/^[-*+]\s+(.*)/)
+    const ordered = line.match(/^\d+[.)]\s+(.*)/)
+    if (unordered || ordered) {
+      flushParagraph()
+      const want = unordered ? 'ul' : 'ol'
+      if (list !== want) { flushList(); out.push(`<${want}>`); list = want }
+      out.push(`<li>${inline(String((unordered || ordered)![1]))}</li>`)
+      continue
+    }
+    if (!line.trim()) { flushParagraph(); flushList(); continue }
+    flushList()
+    paragraph.push(line.trim())
+  }
+  flushParagraph()
+  flushList()
+  if (inCode) out.push(`<pre><code>${escapeHtml(codeLines.join('\n'))}</code></pre>`)
+  return out.join('')
+}

--- a/frontend/src/styles/community/composer.css
+++ b/frontend/src/styles/community/composer.css
@@ -57,3 +57,30 @@
 .composer-tool-panel > label { display: grid; gap: 8px; }
 .composer-tool-panel p { margin: 0; }
 .composer-mobile-top { display: none; }
+.inline-composer { display: grid; gap: 12px; }
+.inline-composer-top { display: flex; align-items: center; gap: 12px; }
+.inline-composer-board { flex-shrink: 0; padding: 6px 12px; border-radius: var(--amc-radius-control); background: var(--amc-orange-soft); color: var(--amc-orange); font-size: 12px; font-weight: 700; white-space: nowrap; }
+.inline-composer-top > input { min-width: 0; flex: 1; height: 40px; border: 1px solid var(--amc-border); border-radius: var(--amc-radius-control); background: var(--amc-surface); padding: 0 12px; font-size: 15px; font-weight: 600; }
+.inline-composer-top > input::placeholder { color: var(--amc-text-placeholder); font-weight: 400; }
+.inline-composer-top .icon-button { flex-shrink: 0; width: 36px; height: 36px; min-width: 36px; min-height: 36px; padding: 0; }
+.inline-composer-toolbar { display: flex; align-items: center; gap: 4px; flex-wrap: wrap; padding: 6px 4px; border: 1px solid var(--amc-border-soft); border-radius: var(--amc-radius-control); background: var(--amc-bg-soft); }
+.inline-composer-toolbar button { display: inline-grid; place-items: center; width: 34px; height: 34px; border: 0; border-radius: var(--amc-radius-xs); background: transparent; color: var(--amc-text-body); font-size: 13px; cursor: pointer; transition: background var(--amc-duration-control) var(--amc-ease), color var(--amc-duration-control) var(--amc-ease); }
+.inline-composer-toolbar button:hover { background: var(--amc-orange-soft); color: var(--amc-orange); }
+.inline-composer-toolbar .md-chip { width: auto; padding: 0 9px; font-size: 12px; font-weight: 700; letter-spacing: .3px; color: var(--amc-orange); background: var(--amc-orange-soft); }
+.inline-composer-toolbar .md-chip:hover { background: var(--amc-orange); color: var(--amc-surface); }
+.inline-composer-toolbar .app-icon { color: currentColor; }
+.inline-composer-content { min-height: 240px; max-height: 60vh; overflow-y: auto; padding: 14px 16px; border: 1px solid var(--amc-border); border-radius: var(--amc-radius-control); background: var(--amc-surface); font-size: 15px; line-height: 1.7; color: var(--amc-text-primary); }
+.inline-composer-content:empty::before { content: attr(data-placeholder); color: var(--amc-text-placeholder); opacity: .72; pointer-events: none; }
+.inline-composer-content:focus-visible { outline: 1px solid var(--amc-orange-border); outline-offset: 1px; }
+.inline-composer-content img { max-width: 100%; border-radius: 8px; margin: 6px 0; }
+.inline-composer-content h3 { font-size: 17px; margin: 10px 0 6px; }
+.inline-composer-content blockquote { margin: 8px 0; padding: 8px 12px; border-left: 3px solid var(--amc-orange-border); background: var(--amc-bg-soft); color: var(--amc-text-body); }
+.inline-composer-content pre { padding: 10px 12px; border-radius: 8px; background: var(--amc-bg-soft); font-family: ui-monospace, SFMono-Regular, Consolas, monospace; font-size: 13px; overflow-x: auto; }
+.inline-composer-content table { border-collapse: collapse; margin: 8px 0; }
+.inline-composer-content td, .inline-composer-content th { border: 1px solid var(--amc-border); padding: 6px 10px; }
+.inline-composer-footer { display: flex; align-items: center; gap: 12px; }
+.inline-composer-hint { flex: 1; color: var(--amc-text-secondary); font-size: 12px; }
+.inline-composer .community-error { margin: 0; }
+.inline-composer-md-paste { display: grid; gap: 8px; padding: 10px 16px; border: 1px solid var(--amc-border); border-radius: var(--amc-radius-control); background: var(--amc-surface); }
+.inline-composer-md-paste textarea { width: 100%; min-height: 120px; resize: vertical; padding: 10px 12px; border: 1px solid var(--amc-border); border-radius: var(--amc-radius-control); background: var(--amc-bg-soft); font: inherit; font-size: 14px; line-height: 1.6; color: var(--amc-text-primary); }
+.inline-composer-md-paste-actions { display: flex; align-items: center; justify-content: flex-end; gap: 12px; }

--- a/frontend/src/views/ResourcesView.vue
+++ b/frontend/src/views/ResourcesView.vue
@@ -11,6 +11,7 @@ import { useCommunityStore } from '../stores/community'
 import { useAuthStore } from '../stores/auth'
 import { mapSelectedResource, useResourcesStore } from '../stores/content/resources'
 import { resourceHubApi } from '../services/api/resourceHub'
+import { ensureAuth } from '../composables/useRequireAuth'
 
 const route = useRoute()
 const router = useRouter()
@@ -46,8 +47,22 @@ const legacyPreviewOpen = computed({
   },
 })
 const publish = (value: ResourceContributionKind) => {
+  if (!ensureAuth('登录后可发布共创内容', () => publish(value))) return
+  if (value === 'article') {
+    community.openComposer({
+      type: 'frontier_discussion',
+      title: '',
+      contentBlocks: [],
+      bindings: [],
+      topicIds: [],
+      visibility: 'public',
+      status: 'published',
+    })
+    community.composerInline = false
+    return
+  }
   community.openComposer({
-    type: value === 'video' ? 'lab_result' : value === 'article' ? 'frontier_discussion' : 'note',
+    type: value === 'video' ? 'lab_result' : 'note',
     title: '',
     contentBlocks: [],
     bindings: [],


### PR DESCRIPTION
## 改动说明（功能块 1/3：极简富文本编辑器与 Markdown 导入）

> 本 PR 为系列三块中的第 1 块，**可独立合并**；后续两块（html 内容块持久化、资源中心优化）基于本块。

### 极简富文本编辑器（CommunityQuickComposer）
- 编辑态重构为单一编辑面板：板块标签 + 标题输入 + 格式工具栏 + contenteditable 正文
- 工具栏支持：加粗、斜体、标题、有序/无序列表、删除线、代码、链接、图片、表格、投票、相机、附件、表情
- 正文支持拖放/粘贴图片（自动上传预览）；编辑器不在视口内时自动平滑滚动聚焦

### 资源中心「写图文」
- 点击「写图文」以弹窗形式打开新编辑器，附 ensureAuth 登录守卫
- 「上传视频 / 分享资料」原有投稿流程保持不变

### Markdown (.md) 导入
- 新增 `markdown.ts`：纯前端 Markdown → HTML 转换（标题、有序/无序列表、引用、围栏代码块、加粗/斜体/删除线、链接、图片），全程 HTML 转义防注入
- 5 种导入方式：工具栏 M↓ 按钮（橙色 chip 样式）、拖放 .md 文件、📎 附件按钮自动路由、Ctrl+V 粘贴 .md 文件、📋 粘贴 Markdown 文本（内嵌面板）
- 导入时自动以文件名填充空标题

### 草稿体验
- 关闭编辑器不再弹出「保留未完成的内容」询问框，自动保存至草稿箱后关闭
- 移除编辑框下方「草稿箱」入口文字（草稿箱页面及个人页入口保留）

### 已知限制（由功能块 2 解决）
- 内容块模型（paragraph/code/image/quote）不含行内富文本，编辑器格式发布后降级为纯文本
